### PR TITLE
Fixup: Wrong selection of vt_type

### DIFF
--- a/avocado-setup.py
+++ b/avocado-setup.py
@@ -75,8 +75,9 @@ class TestSuite():
                                              self.shortname)
             if not os.path.isfile(local_cfg):
                 return self.conf
-            cfg = "%s/avocado-vt/backends/libvirt/cfg/%s.cfg" % (DATA_DIR,
-                                                                 self.shortname)
+            cfg = "%s/avocado-vt/backends/%s/cfg/%s.cfg" % (DATA_DIR,
+                                                            self.vt_type,
+                                                            self.shortname)
             cmd = 'cp -f %s %s' % (local_cfg, cfg)
             os.system(cmd)
             self.conf = cfg


### PR DESCRIPTION
This patch fixes the wrong selection of vt_type incase
qemu as earlier libvirt was always chosen as destination config
folder irrespective of vt_type