### PR TITLE
Fixup:Wrong cpu range in numa config for memory hotplug test

### DIFF
--- a/config/tests/guest/libvirt/sanity.cfg
+++ b/config/tests/guest/libvirt/sanity.cfg
@@ -182,7 +182,7 @@ variants:
                         max_mem_rt = 67108864
                         max_mem = 33554432
                         vcpu = 32
-                        numa_cells = "{'id':'0','cpus':'0-32','memory':'33554432','unit':'KiB'}"
+                        numa_cells = "{'id':'0','cpus':'0-31','memory':'33554432','unit':'KiB'}"
                         test_dom_xml = "no"
                         tg_size = 8388608
                         only libvirt_mem.positive_test.hot_plug


### PR DESCRIPTION
Instead of 0-31 which is a valid range 0-32 was used which caused
failure of the test, this patch will address the same