### PR TITLE
Add psmisc, virt-install and mlocate to deps list

### DIFF
--- a/config/wrapper/env.conf
+++ b/config/wrapper/env.conf
@@ -4,4 +4,4 @@ avocado_vt = https://github.com/avocado-framework/avocado-vt.git
 tests = https://github.com/avocado-framework/avocado-misc-tests.git
 
 [deps]
-packages = gcc,python-devel,p7zip,python-setuptools,libvirt-devel,tcpdump
+packages = gcc,python-devel,p7zip,python-setuptools,libvirt-devel,tcpdump,psmisc,virt-install,mlocate


### PR DESCRIPTION
I've tried to use the tests and noticed some failures due to lack of some packages: psmisc (contains fuser), virt-install mlocate (contains locate). The packages are used avocado-vt but the same situation happens for tcpdump for instance so I think those are good candidates for dependency list.