### PR TITLE
Updated avocado-misc-tests repository

### DIFF
--- a/config/wrapper/env.conf
+++ b/config/wrapper/env.conf
@@ -1,7 +1,7 @@
 [repo]
 avocado = https://github.com/avocado-framework/avocado.git
 avocado_vt = https://github.com/avocado-framework/avocado-vt.git
-tests = https://github.com/avocado-framework/avocado-misc-tests.git
+tests = https://github.com/avocado-framework-tests/avocado-misc-tests.git
 
 [deps]
 packages = gcc,python-devel,p7zip,python-setuptools,libvirt-devel,tcpdump,psmisc,virt-install,mlocate


### PR DESCRIPTION
Location of avocado-misc-tests repository has been moved in
upstream, hence updated the new repo link in the config file.