### PR TITLE
Skip gdb- check and ltp.py host test

### DIFF
--- a/config/tests/host/sanity.cfg
+++ b/config/tests/host/sanity.cfg
@@ -5,7 +5,7 @@ avocado-misc-tests/cpu/ebizzy.py
 # IO-disk
 avocado-misc-tests/io/disk/dbench.py
 # Kernel
-avocado-misc-tests/generic/ltp.py
+#avocado-misc-tests/generic/ltp.py
 # Memory
 avocado-misc-tests/memory/libhugetlbfs.py
 # Services

--- a/config/wrapper/env.conf
+++ b/config/wrapper/env.conf
@@ -4,4 +4,4 @@ avocado_vt = https://github.com/avocado-framework/avocado-vt.git
 tests = https://github.com/avocado-framework-tests/avocado-misc-tests.git
 
 [deps]
-packages = gcc,python-devel,p7zip,python-setuptools,libvirt-devel,tcpdump,psmisc,virt-install,mlocate,numactl,genisoimage,git,libtool,patch,targetcli,attr,gdb-,python-stevedore
+packages = gcc,python-devel,p7zip,python-setuptools,libvirt-devel,tcpdump,psmisc,virt-install,mlocate,numactl,genisoimage,git,libtool,patch,targetcli,attr,python-stevedore


### PR DESCRIPTION
Removed "gdb-" from prerequisite check until issue with it is resolved. Skipped ltp.py Host sanity test until issue with subset of tests is resolved.  This change will be reverted in a future PR once associated issues are resolved.