### PR TITLE
Remove test from Guest sanity.cfg

### DIFF
--- a/config/tests/guest/libvirt/sanity.cfg
+++ b/config/tests/guest/libvirt/sanity.cfg
@@ -307,19 +307,20 @@ variants:
                         vcpu_threads = 8
                         vcpu_sockets = 1
                         only unattended_install.import.import.default_install.aio_native,remove_guest.without_disk
-                    - network_max:
-                        only qcow2
-                        only scsi
-                        variants:
-                            - spaprvlan:
-                                only spapr-vlan
-                                nics += ' nic2 nic3 nic4 nic5 nic6 nic7 nic8 nic9 nic10 nic11 nic12 nic13 nic14 nic15 nic16'
-                                only unattended_install.import.import.default_install.aio_native,remove_guest.without_disk
-                            - virtionet:
-                                only virtio_net
-                                nic_model_nic1 = spapr-vlan
-                                nics += ' nic2 nic3 nic4 nic5 nic6 nic7 nic8 nic9 nic10 nic11 nic12 nic13 nic14 nic15 nic16'
-                                only unattended_install.import.import.default_install.aio_native,remove_guest.without_disk
+                    # Commenting out failing network_max tests until associated bug is fixed - Reina Quander 2016-12-19
+#                    - network_max:
+#                        only qcow2
+#                        only scsi
+#                        variants:
+#                            - spaprvlan:
+#                                only spapr-vlan
+#                                nics += ' nic2 nic3 nic4 nic5 nic6 nic7 nic8 nic9 nic10 nic11 nic12 nic13 nic14 nic15 nic16'
+#                                only unattended_install.import.import.default_install.aio_native,remove_guest.without_disk
+#                            - virtionet:
+#                                only virtio_net
+#                                nic_model_nic1 = spapr-vlan
+#                                nics += ' nic2 nic3 nic4 nic5 nic6 nic7 nic8 nic9 nic10 nic11 nic12 nic13 nic14 nic15 nic16'
+#                                only unattended_install.import.import.default_install.aio_native,remove_guest.without_disk
                     - disk:
                         only qcow2
                         only spapr-vlan


### PR DESCRIPTION
Commented out network_max boundary tests from the Guest sanity.cfg file until the associated issue #10 is resolved.