### PR TITLE
Fixup: Set a flag for flexible nic index check

### DIFF
--- a/config/tests/guest/libvirt/sanity.cfg
+++ b/config/tests/guest/libvirt/sanity.cfg
@@ -308,6 +308,7 @@ variants:
                         vcpu_sockets = 1
                         only unattended_install.import.import.default_install.aio_native,remove_guest.without_disk
                     - network_max:
+                        flexible_nic_index = yes
                         only qcow2
                         only scsi
                         variants:


### PR DESCRIPTION
Have set a flag for flexible nic index flag and inorder
to get the IP address incase of multiple interfaces
given for guest.

Depends on upstream avocado-vt commit
https://github.com/avocado-framework/avocado-vt/commit/387d9a32e26a4a3f7936d908c28930712b2b7aa6

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>