### PR TITLE
Added multiple features and fixes

### DIFF
--- a/avocado-setup.py
+++ b/avocado-setup.py
@@ -13,9 +13,10 @@
 #
 # Python wrapper for avocado
 # Author: Satheesh Rajendran<sathnaga@linux.vnet.ibm.com>
-#
 
 import os
+import shutil
+import time
 import re
 import commands
 import sys
@@ -30,11 +31,12 @@ CONFIG_PATH = "%s/config/wrapper/env.conf" % BASE_PATH
 TEST_CONF_PATH = "%s/config/tests/" % BASE_PATH
 CONFIGFILE = ConfigParser.SafeConfigParser()
 CONFIGFILE.read(CONFIG_PATH)
+INPUTFILE = ConfigParser.SafeConfigParser()
+INPUTFILE.optionxform = str
 AVOCADO_REPO = CONFIGFILE.get('repo', 'avocado')
 AVOCADO_VT_REPO = CONFIGFILE.get('repo', 'avocado_vt')
 TEST_REPOS = CONFIGFILE.get('repo', 'tests').split(',')
 REPOS = [AVOCADO_REPO, AVOCADO_VT_REPO]
-ENV_DEPS = CONFIGFILE.get('deps', 'packages').split(',')
 TEST_DIR = "%s/tests" % BASE_PATH
 DATA_DIR = "%s/data" % BASE_PATH
 LOG_DIR = "%s/results" % BASE_PATH
@@ -43,8 +45,10 @@ logger = logger_init(filepath=BASE_PATH).getlogger()
 
 
 class TestSuite():
+    guest_add_args = ""
+    host_add_args = ""
 
-    def __init__(self, name, resultdir, vt_type):
+    def __init__(self, name, resultdir, vt_type, test=None, mux=None):
         self.id = binascii.b2a_hex(os.urandom(20))
         self.name = str(name)
         self.shortname = "_".join(self.name.split('_')[1:])
@@ -52,7 +56,9 @@ class TestSuite():
         self.type = str(name.split('_')[0])
         self.resultdir = resultdir
         self.conf = None
-        self.run = "Not Run"
+        self.test = test
+        self.mux = mux
+        self.run = "Not_Run"
         self.runsummary = None
         self.runlink = None
         if self.type == 'guest':
@@ -95,16 +101,22 @@ class TestSuite():
         self.runlink = link
 
 
-def is_present(package, package_list):
+def get_dist():
     """
-    Check if the given package is installed in the system
-    :param package: Name of the package
+    Return the distribution
     """
-    result = re.findall('^%s-[0-9].*' % package, package_list, re.M)
-    if result:
-        return True
-    else:
-        return False
+    dist = None
+    if os.path.isfile('/etc/os-release'):
+        fd = open('/etc/os-release', 'r')
+        for line in fd.readlines():
+            if line.startswith("ID="):
+                try:
+                    line = line.replace('"', '')
+                    dist = re.findall("ID=(\S+)", line)[0]
+                except:
+                    pass
+        fd.close()
+    return dist
 
 
 def get_avocado_bin():
@@ -125,24 +137,51 @@ def env_check():
     Check if the environment is proper
     """
     logger.info("Check for environment")
-    # :TODO: Check expects rpm to be available in system
-    # this is not true in all distributions
-    status, pack_list = commands.getstatusoutput("rpm -qa")
-    if status != 0:
-        logger.error("rpm command failed, please ensure "
-                     "the deps are installed manually and "
-                     "proceed\n List of deps: %s", ' '.join(ENV_DEPS))
-        # We are not exiting here as we might not know at this place
-        # the env deps are satisfied or not,above :TODO: to be addressed
+    # create a folder to store all edited multiplexer files
+    if not os.path.isdir("/tmp/mux/"):
+        logger.info("Creating temporary mux dir")
+        os.makedirs("/tmp/mux/")
+    not_found = []
+    dist = get_dist()
+    if os.uname()[-1] == 'ppc64':
+        dist = '%sbe' % dist
+    if CONFIGFILE.has_section('deps_%s' % dist):
+        env_deps = CONFIGFILE.get('deps_%s' % dist, 'packages').split(',')
     else:
-        not_found = []
-        for dep in ENV_DEPS:
-            if not is_present(dep, pack_list):
-                not_found.append(dep)
-        if not_found:
+        # Not able to find the distribution, try use rpm
+        env_deps = CONFIGFILE.get('deps_centos', 'packages').split(',')
+
+    for dep in env_deps:
+        if 'ubuntu' in dist:
+            cmd = "dpkg -l|grep  ' %s'" % dep
+        else:
+            cmd = "rpm -qa|grep %s" % dep
+        status, output = commands.getstatusoutput(cmd)
+        if status != 0:
+            not_found.append(dep)
+    if not_found:
+        if args.no_deps_check:
+            logger.warning(
+                "No dependancy check flag is set, proceeding with bootstrap")
             logger.info("Please install following "
                         "dependancy packages %s", " ".join(not_found))
+        else:
+            logger.error("Please install following "
+                         "dependancy packages %s", " ".join(not_found))
             sys.exit(1)
+
+
+def is_avocado_plugin_avl(plugin):
+    """
+    Check if the given avocado plugin installed
+    """
+    cmd = 'avocado plugins|grep %s' % plugin
+    status, output = commands.getstatusoutput(cmd)
+    if status != 0:
+        logger.warning("Avocado %s plugin not installed", plugin)
+        return False
+    else:
+        return True
 
 
 def need_bootstrap():
@@ -150,7 +189,7 @@ def need_bootstrap():
     Check if bootstrap required
     :return: True if bootstrap is needed
     """
-    logger.info("Check if bootstrap required")
+    logger.debug("Check if bootstrap required")
     needsBootstrap = False
     # Check for avocado
     status, output = commands.getstatusoutput('avocado')
@@ -159,9 +198,7 @@ def need_bootstrap():
         needsBootstrap = True
     # Check for avocado-vt
     for plugin in ['vt', 'vt-list', 'vt-bootstrap']:
-        cmd = 'avocado plugins|grep %s' % plugin
-        status, output = commands.getstatusoutput(cmd)
-        if status != 0:
+        if not is_avocado_plugin_avl(plugin):
             logger.info("Avocado %s plugin needs to installed", plugin)
             needsBootstrap = True
     # Check for avocado-tests
@@ -186,14 +223,16 @@ def get_repo(repo, basepath, install=False):
         logger.info("Updating the repo: %s in %s", repo_name, repo_path)
         cmd = "cd %s;git remote update;git merge origin master" % repo_path
         try:
-            commands.getstatusoutput(cmd)
+            status, output = commands.getstatusoutput(cmd)
+            logger.debug("Update Repo: %s\n%s", repo_name, output)
         except Exception, error:
             logger.error("Failed to update %s ", error)
             sys.exit(1)
     else:
         cmd = "cd %s;git clone %s %s" % (basepath, repo, repo_name)
         try:
-            commands.getstatusoutput(cmd)
+            status, output = commands.getstatusoutput(cmd)
+            logger.debug("Clone repo: %s\n%s", repo_name, output)
         except Exception, error:
             logger.error("Failed to clone %s", error)
             sys.exit(1)
@@ -210,16 +249,36 @@ def install_repo(path):
     cmd = "cd %s;make requirements;python setup.py install" % path
     try:
         status, output = commands.getstatusoutput(cmd)
+        logger.debug("%s", output)
         if status != 0:
             logger.error("Error while installing: %s\n%s",
                          path.split('/')[-1], status)
             sys.exit(1)
-        else:
-            logger.debug("%s", output)
     except Exception, error:
         logger.error("Failed with exception during installing %s\n%s",
                      path.split('/')[-1], error)
         sys.exit(1)
+
+
+def install_optional_plugin(plugin):
+    """
+    To install optional avocado plugin
+    :param plugin: optional plugin name
+    """
+    if not is_avocado_plugin_avl(plugin):
+        logger.info("Installing optional plugin: %s", plugin)
+        plugin_path = "%s/avocado/optional_plugins/%s" % (BASE_PATH, plugin)
+        if os.path.isdir(plugin_path):
+            cmd = "cd %s;python setup.py install" % plugin_path
+            status, output = commands.getstatusoutput(cmd)
+            if status != 0:
+                logger.error("Error installing optional plugin: %s", plugin)
+        else:
+            logger.warning("optional plugin %s is not present in path %s,"
+                           " skipping install", plugin, plugin_path)
+    else:
+        # plugin already installed
+        pass
 
 
 def create_config(logdir):
@@ -244,58 +303,201 @@ def create_config(logdir):
         config.write(conf)
 
 
+def vt_bootstrap(guestos):
+    """
+    Guest image downloading
+    """
+    avocado_bin = get_avocado_bin()
+    logger.info("Downloading the guest os image")
+    cmd = '%s vt-bootstrap --vt-guest-os %s --yes-to-all' % (avocado_bin,
+                                                             guestos)
+    try:
+        status, output = commands.getstatusoutput(cmd)
+        logger.debug("%s", output)
+    except Exception, error:
+        logger.error("Failed to Download Guest OS. Error: %s ", error)
+        sys.exit(1)
+
+
 def bootstrap():
     """
     Prepare the environment for execution
     """
-    logger.info("Bootstraping")
+    env_clean()
+    logger.info("Bootstrapping")
     # Check if the avocado and avocado-vt installed in the system
     for repo in REPOS:
         get_repo(repo, BASE_PATH, True)
-    # bootstrap_vt
     avocado_bin = get_avocado_bin()
+    # bootstrap_vt
+    logger.info("Bootstrapping vt libvirt")
     libvirt_cmd = '%s vt-bootstrap --vt-type libvirt \
-                    --vt-no-downloads --yes-to-all' % avocado_bin
-    os.system(libvirt_cmd)
-    qemu_cmd = '%s vt-bootstrap --vt-type qemu --vt-no-downloads' % avocado_bin
-    os.system(qemu_cmd)
+                  --vt-update-providers --vt-skip-verify-download-assets \
+                  --yes-to-all' % avocado_bin
+    try:
+        status, output = commands.getstatusoutput(libvirt_cmd)
+        logger.debug("%s", output)
+    except Exception, error:
+        logger.error("Failed to bootstrap vt libvirt. Error: %s ", error)
+        sys.exit(1)
+    logger.info("Bootstrapping vt qemu")
+    qemu_cmd = '%s vt-bootstrap --vt-type qemu --vt-update-providers \
+               --vt-skip-verify-download-assets' % avocado_bin
+    try:
+        status, output = commands.getstatusoutput(qemu_cmd)
+        logger.debug("%s", output)
+    except Exception, error:
+        logger.error("Failed to bootstrap vt qemu. Error: %s ", error)
+        sys.exit(1)
     for repo in TEST_REPOS:
-        os.system('mkdir -p %s' % TEST_DIR)
+        try:
+            logger.info("creating test repo dir %s", TEST_DIR)
+            status, output = commands.getstatusoutput('mkdir -p %s' % TEST_DIR)
+            logger.debug("%s", output)
+        except Exception, error:
+            logger.error("Failed to create test repo dir. Error: %s", error)
         get_repo(repo, TEST_DIR)
 
 
-def run_test(testsuite, args=None):
+def run_test(testsuite, avocado_bin):
     """
     To run given testsuite
     :param testsuite: Testsuite object which has details about the tests
-    :param args: if any additional arguments
+    :param avocado_bin: Executable path of avocado
     """
-    conf = testsuite.config()
-    test_type = testsuite.type
-    vt_type = testsuite.vt_type
-    avocado_bin = get_avocado_bin()
-    if 'guest' in test_type:
+    logger.info('')
+    if 'guest' in testsuite.type:
+        guest_args = TestSuite.guest_add_args
         logger.info("Running Guest Tests Suite %s", testsuite.shortname)
+        if "sanity" in testsuite.shortname:
+            guest_args = " --vt-only-filter %s " % args.guest_os
         cmd = "%s run --vt-type %s --vt-config %s \
-                --force-job-id %s" % (avocado_bin, vt_type, conf, testsuite.id)
-    if 'host' in test_type:
+                --force-job-id %s %s" % (avocado_bin, testsuite.vt_type,
+                                         testsuite.config(),
+                                         testsuite.id, guest_args)
+    if 'host' in testsuite.type:
         logger.info("Running Host Tests Suite %s", testsuite.shortname)
-        cmd = "%s run  --force-job-id %s \
-                $(cat %s|grep -v '^#')" % (avocado_bin, testsuite.id, conf)
-    if args:
-        cmd += " %s" % args
+        cmd = "%s run %s" % (avocado_bin, testsuite.test)
+        if testsuite.mux:
+            cmd += " -m %s" % os.path.join(TEST_DIR, testsuite.mux)
+        cmd += " --force-job-id %s %s" % (testsuite.id, TestSuite.host_add_args)
+
     try:
-        logger.debug("Running: %s", cmd)
+        logger.info("Running: %s", cmd)
         os.system(cmd)
     except Exception, error:
-        logger.info("Running testsuite %s failed with error\n%s",
-                    testsuite.name, error)
-        testsuite.runstatus("Not Run", "command execution failed")
+        logger.error("Running testsuite %s failed with error\n%s",
+                     testsuite.name, error)
+        testsuite.runstatus("Not_Run", "command execution failed")
         return
-    result_link = "%s/html/results.html" % testsuite.jobdir()
-    testsuite.runstatus("Run", "Sucussfully executed", result_link)
+    logger.info('')
+    result_link = "%s/job.log" % testsuite.jobdir()
+    testsuite.runstatus("Run", "Successfully executed", result_link)
     return
 
+
+def env_clean():
+    """
+    Clean/uninstall avocado and autotest
+    """
+    logger.info("Uninstalling avocado and autotest from environment")
+    for package in ['avocado', 'avocado_plugins_vt', 'autotest']:
+        cmd = "yes|pip uninstall %s" % package
+        try:
+            (status, output) = commands.getstatusoutput(cmd)
+            logger.debug("%s", output)
+        except:
+            logger.error("Error in removing %s package: %s", package, output)
+
+
+def edit_mux_file(test_config_name, mux_file_path, tmp_mux_path):
+    """
+    Edit the mux file with input given in  input config file.
+    """
+    INPUTFILE.read(args.inputfile)
+    if INPUTFILE.has_section(test_config_name):
+        input_dic = {}
+        for input_line in INPUTFILE.items(test_config_name):
+            input_dic[input_line[0]] = input_line[1]
+    else:
+        logger.debug("Section %s not found in input file", test_config_name)
+        return
+
+    with open(mux_file_path) as mux_fp:
+        mux_str = mux_fp.read()
+
+    mux_str_edited = []
+    for line in mux_str.splitlines():
+        if len(line) == 0 or line.lstrip()[0] == '#':
+            continue
+        for key, value in input_dic.iteritems():
+            temp_line = line.split(":")
+            mux_key = temp_line[0]
+            mux_value = temp_line[1]
+            if key == mux_key.strip():
+                line = line.replace('%s' % line.strip(), '%s: %s' % (key, value))
+        mux_str_edited.append(line)
+
+    with open(tmp_mux_path, 'w') as mux_fp:
+        mux_fp.write(str("\n".join(mux_str_edited)))
+
+
+def parse_test_config(test_config_file, avocado_bin):
+    """
+    Parses Test Config file and returns list of indivual tests dictionaries,
+    with test path and yaml file path.
+    """
+    test_config_type = test_config_file[:test_config_file.find("_")]
+    test_config_name = test_config_file[test_config_file.find("_") + 1:]
+    test_config_file = "%s/%s/%s.cfg" % (TEST_CONF_PATH, test_config_type,
+                                         test_config_name)
+    if not os.path.isfile(test_config_file):
+        logger.error("Test Config %s not present", test_config_file)
+    else:
+        with open(test_config_file, 'r') as fp:
+            test_config_contents = fp.read()
+        test_list = []
+        mux_flag = 0
+        for line in test_config_contents.splitlines():
+            test_dic = {}
+            if line.startswith("#"):
+                continue
+            line = line.split()
+            test_dic['test'] = line[0].strip('$')
+            test_dic['name'] = test_dic['test'].split("/")[-1]
+            if ":" in test_dic['test'].split("/")[-1]:
+                test_dic['name'] = "%s_%s" % (test_dic['name'].split(".")[0],
+                                              test_dic['name'].split(":")[-1].replace(".", "_"))
+                test_dic['test'] = "%s$" % test_dic['test']
+            else:
+                test_dic['name'] = test_dic['name'].split(".")[0]
+            cmd = "%s list %s 2> /dev/null" % (avocado_bin, test_dic['test'])
+            (status, output) = commands.getstatusoutput(cmd)
+            logger.debug("%s does not exist", test_dic['test'])
+            if status != 0:
+                continue
+            if len(line) > 1:
+                test_dic['mux'] = line[1]
+                mux_flag = 1
+                test_dic['name'] = "%s_%s" % (test_dic['name'], test_dic['mux'].split("/")[-1].split(".")[0])
+                if args.inputfile:
+                    mux_file = os.path.join(TEST_DIR, test_dic['mux'])
+                    if not os.path.isfile(mux_file):
+                        logger.debug("%s does not exist", mux_file)
+                        continue
+                    tmp_mux_path = os.path.join('/tmp/mux/', "%s_%s.yaml" % (test_config_name, test_dic['name']))
+                    edit_mux_file(test_config_name, mux_file, tmp_mux_path)
+                    test_dic['mux'] = tmp_mux_path
+            test_list.append(test_dic)
+        if mux_flag == 0:
+            single_test_dic = {}
+            single_test_dic['name'] = test_config_name
+            single_test_dic['test'] = ''
+            for test in test_list:
+                single_test_dic['test'] += " %s" % test['test']
+            return [single_test_dic]
+
+        return test_list
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
@@ -308,23 +510,29 @@ if __name__ == '__main__':
     parser.add_argument('--output-dir', dest='outputdir',
                         action='store', default=None,
                         help='Specify the custom test results directory')
+    parser.add_argument('--input-file', dest='inputfile',
+                        action='store', default=None,
+                        help='Specify input file for custom mux values for host tests')
+    parser.add_argument('--interval-time', dest='interval',
+                        action='store', default=None,
+                        help='Specify the interval time between tests')
     parser.add_argument('--verbose', dest='verbose',
                         action='store_true', default=False,
                         help='Enable verbose output on the console')
     parser.add_argument('--only-filter', dest='only_filter',
-                        action='store', default=None,
+                        action='store', default="",
                         help='Add filters to include specific avocado tests,'
                         'features from the guest test suite')
     parser.add_argument('--no-filter', dest='no_filter',
-                        action='store', default=None,
+                        action='store', default="",
                         help='Add filters to exclude specific avocado tests,'
                         'features from the guest test suite')
     parser.add_argument('--additional-args', dest='add_args',
-                        action='store', default=None,
+                        action='store', default="",
                         help='Pass additional arguments to the command')
     parser.add_argument('--guest-os', dest='guest_os',
-                        action='store', default='Fedora.24.ppc64le',
-                        help='Provide Guest os: Default: Fedora.24.ppc64le')
+                        action='store', default='CentOS.7.3.ppc64le',
+                        help='Provide Guest os: Default: CentOS.7.3.ppc64le')
     parser.add_argument('--vt', dest='vt_type',
                         action='store', choices=['qemu', 'libvirt'],
                         default='libvirt',
@@ -332,12 +540,21 @@ if __name__ == '__main__':
     parser.add_argument('--install', dest='install_guest',
                         action='store_true', default=False,
                         help='Install the Guest VM, if needed.')
+    parser.add_argument('--no-download', dest='no_guest_download',
+                        action='store_true', default=False,
+                        help='To download the preinstalled guest image')
+    parser.add_argument('--no-deps-check', dest="no_deps_check",
+                        action='store_true', default=False,
+                        help='To force wrapper not to check for dependancy packages')
+    parser.add_argument('--clean', dest="clean",
+                        action='store_true', default=False,
+                        help='To remove/uninstall autotest, avocado from system')
 
     args = parser.parse_args()
     env_check()
-    additional_args = ' --output-check-record all'
+    additional_args = args.add_args
     if args.verbose:
-        additional_args = ' --show-job-log'
+        additional_args += ' --show-job-log'
     if args.outputdir:
         # Check if it valid path
         if not os.path.isdir(os.path.abspath(args.outputdir)):
@@ -348,9 +565,13 @@ if __name__ == '__main__':
 
     additional_args += ' --job-results-dir %s' % outputdir
 
-    if args.bootstrap or need_bootstrap():
+    if (args.bootstrap or need_bootstrap()):
         create_config(outputdir)
         bootstrap()
+        # Install optional plugins from config file
+        plugins = CONFIGFILE.get('plugins', 'optional').split(',')
+        for plugin in plugins:
+            install_optional_plugin(plugin)
         # Copy if any isos present in the local folder
         dst_iso_path = "%s/avocado-vt/isos/linux/" % DATA_DIR
         if not os.path.isdir(dst_iso_path):
@@ -361,42 +582,86 @@ if __name__ == '__main__':
                 dst_file = os.path.join(dst_iso_path, fle)
                 copyfile(file_path, dst_file)
 
+    if args.inputfile:
+        if not os.path.isfile(args.inputfile):
+            logger.debug("Input file %s not found. Continuing without input file", args.inputfile)
+            args.inputfile = None
+
     if args.run_suite:
+        if "guest_" in args.run_suite:
+            # Make sure we download guest image once
+            if not args.no_guest_download:
+                vt_bootstrap(args.guest_os)
+            only_filter = args.only_filter
+            if only_filter:
+                only_filter += ' %s' % args.guest_os
+            else:
+                only_filter = args.guest_os
+            if only_filter:
+                TestSuite.guest_add_args += ' --vt-only-filter \
+                                            "%s"' % only_filter
+            if args.no_filter:
+                TestSuite.guest_add_args += ' --vt-no-filter \
+                                            "%s"' % args.no_filter
+            if additional_args:
+                TestSuite.guest_add_args += additional_args
+        if "host_" in args.run_suite:
+            TestSuite.host_add_args = additional_args
         test_suites = args.run_suite.split(',')
         if args.install_guest:
             test_suites.insert(0, 'guest_install')
+        avocado_bin = get_avocado_bin()
         Testsuites = {}
         # Validate if given test suite is available
-        # run Guest tests
+        # and init TestSuite object for each test suite
+        Testsuites_list = []
         for test_suite in test_suites:
-            Testsuites[test_suite] = TestSuite(str(test_suite),
-                                               outputdir, args.vt_type)
-            if not Testsuites[test_suite].config():
-                Testsuites[test_suite].runstatus("Not Run",
-                                                 "Config file not present")
-                continue
-            if 'guest' in Testsuites[test_suite].type:
-                only_filter = None
-                if args.only_filter:
-                    only_filter = args.only_filter
-                if args.guest_os:
-                    if only_filter:
-                        only_filter += ' %s' % args.guest_os
-                    else:
-                        only_filter = args.guest_os
-                    if only_filter:
-                        additional_args += ' --vt-only-filter \
-                                        "%s"' % only_filter
-                if args.no_filter:
-                    additional_args += ' --vt-no-filter "%s"' % args.no_filter
-            if args.add_args:
-                additional_args += " %s" % args.add_args
-            run_test(Testsuites[test_suite], additional_args)
+            if 'host' in test_suite:
+                test_list = parse_test_config(test_suite, avocado_bin)
+                if test_list is None:
+                    Testsuites[test_suite] = TestSuite(test_suite, outputdir,
+                                                       args.vt_type)
+                    Testsuites[test_suite].runstatus("Cant_Run",
+                                                     "Config file not present")
+                    continue
+                for test in test_list:
+                    if not test.has_key('mux'):
+                        test['mux'] = ''
+                    test_suite_name = "%s_%s" % (test_suite, test['name'])
+                    Testsuites[test_suite_name] = TestSuite(test_suite_name,
+                                                            outputdir, args.vt_type,
+                                                            test['test'], test['mux'])
+                    Testsuites_list.append(test_suite_name)
+
+            if 'guest' in test_suite:
+                guest_additional_args = ""
+                Testsuites[test_suite] = TestSuite(str(test_suite),
+                                                   outputdir, args.vt_type)
+                Testsuites_list.append(str(test_suite))
+                if not Testsuites[test_suite].config():
+                    Testsuites[test_suite].runstatus("Cant_Run",
+                                                     "Config file not present")
+                    continue
+        # Run Tests
+        for test_suite in Testsuites_list:
+            if not Testsuites[test_suite].run == "Cant_Run":
+                run_test(Testsuites[test_suite], avocado_bin)
+                if args.interval:
+                    time.sleep(int(args.interval))
+
         # List the final output
-        logger.info("Summary of test results can be found below: "
-                    "\nTestSuite\tTestrun\tResultLink\t\t\tSummary\n\n")
-        for test_suite in test_suites:
-            print '%s\t%s\t%s\t%s\n' % (Testsuites[test_suite].name,
-                                        Testsuites[test_suite].run,
-                                        Testsuites[test_suite].runlink,
-                                        Testsuites[test_suite].runsummary)
+        summary_output = ["Summary of test results can be found below:\n%-25s %-10s %-85s %-20s" % ('TestSuite', 'Testrun', 'ResultLink', 'Summary')]
+
+        for test_suite in Testsuites_list:
+            summary_output.append('%-25s %-10s %-85s %-20s' % (Testsuites[test_suite].name,
+                                                               Testsuites[test_suite].run,
+                                                               Testsuites[test_suite].runlink,
+                                                               Testsuites[test_suite].runsummary))
+        logger.info("\n".join(summary_output))
+
+    if os.path.isdir("/tmp/mux/"):
+        logger.info("Removing temporary mux dir")
+        shutil.rmtree("/tmp/mux/")
+
+    if args.clean:
+        env_clean()

--- a/config/wrapper/env.conf
+++ b/config/wrapper/env.conf
@@ -3,5 +3,16 @@ avocado = https://github.com/avocado-framework/avocado.git
 avocado_vt = https://github.com/avocado-framework/avocado-vt.git
 tests = https://github.com/avocado-framework-tests/avocado-misc-tests.git
 
-[deps]
+[deps_centos]
 packages = gcc,python-devel,p7zip,python-setuptools,libvirt-devel,tcpdump,psmisc,virt-install,mlocate,numactl,genisoimage,git,libtool,patch,targetcli,attr,python-stevedore,qemu,libvirt,SLOF,python2-pip
+[deps_ubuntu]
+packages = gcc,python-dev,p7zip,python-setuptools,libvirt-dev,tcpdump,numactl,libosinfo-1.0-0,attr
+[deps_rhel]
+packages = gcc,python-devel,xz-devel,python-setuptools,libvirt-devel,tcpdump,virt-install,qemu,libvirt,SLOF,genisoimage,numactl,attr,policycoreutils-python
+[deps_rhelbe]
+packages = gcc,python-devel,xz-devel,python-setuptools,libvirt-devel,tcpdump,libvirt,SLOF,genisoimage,numactl
+[deps_sles]
+packages = gcc,python-devel,p7zip,xz-devel,python-setuptools,libvirt-devel,tcpdump,virt-install,qemu,libvirt,genisoimage,numactl
+
+[plugins]
+optional = html,varianter_yaml_to_mux

--- a/lib/logger.py
+++ b/lib/logger.py
@@ -10,8 +10,9 @@
 # GNU General Public License for more details.
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-# Author: Satheesh Rajendran<sathnaga@linux.vnet.ibm.com>
 #
+# Python wrapper for avocado
+# Author: Satheesh Rajendran<sathnaga@linux.vnet.ibm.com>
 
 
 import os
@@ -29,8 +30,12 @@ class logger_init:
             self.name = name
             self.filepath = filepath
             self.filename = None
-            formatter = logging.Formatter(
-                '%(asctime)s %(levelname)s: [%(filename)s:%(lineno)d] %(message)s')
+            file_formatter = logging.Formatter(
+                '%(asctime)s %(levelname)-8s: [%(filename)s:%(lineno)d] %(message)s',
+                '%Y-%m-%d %H:%M:%S')
+            console_formatter = logging.Formatter(
+                '%(asctime)s %(levelname)-8s: %(message)s',
+                '%H:%M:%S')
 
             if not self.filepath:
                 self.filename = "/tmp/%s.log" % self.name
@@ -40,11 +45,13 @@ class logger_init:
                 self.filename = "%s/%s.log" % (self.filepath, self.name)
 
             self.file_hdlr = logging.FileHandler(self.filename)
-            self.file_hdlr.setFormatter(formatter)
+            self.file_hdlr.setFormatter(file_formatter)
+            self.file_hdlr.setLevel(logging.DEBUG)
             self.logger.addHandler(self.file_hdlr)
 
             self.console_handler = logging.StreamHandler()
-            self.console_handler.setFormatter(formatter)
+            self.console_handler.setFormatter(console_formatter)
+            self.console_handler.setLevel(logging.INFO)
             self.logger.addHandler(self.console_handler)
             self.logger.handler_set = True
 


### PR DESCRIPTION
1. Added Host tests multiplexer support
given this, host tests cfg takes multiplexer inputs
2. Added additional plugins install support
3. Handled multiple distributions like Ubunutu,RHEL etc
4. Improved logging
5. Modified to adopt new commandline changes in avocado
6. Updated default guest image to CentOS.7.3.ppc64le
7. Following new arguments added to wrapper
--input-file INPUTFILE Provide the input file to be used for host tests
--no-download          Use this option not to download the guest image incase
                       of using preinstalled guest image
--no-deps-check        To force wrapper not to check for dependancy packages
--clean                To remove/uninstall autotest, avocado from system

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>
Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>