### PR TITLE
Add additional tests to cpu bucket and chnage default setting

### DIFF
--- a/config/tests/guest/libvirt/sanity.cfg
+++ b/config/tests/guest/libvirt/sanity.cfg
@@ -39,9 +39,9 @@ variants:
     - guest_sanity:
         variants:
             - cpu:
-                only spapr-vlan
+                only virtio_net
                 only qcow2
-                only scsi
+                only virtio_scsi
                 variants:
                     - import:
                         only unattended_install.import.import.default_install.aio_native
@@ -51,6 +51,8 @@ variants:
                         only virsh.nodecpustats.positive_test.option1,virsh.nodecpustats.negative_test.no_option
                     - cpu_baseline:
                         only virsh.cpu_baseline.positive_tests.running_test.no_option,virsh.cpu_baseline.negative_tests.running_test.wrong_option
+                    - emulatorpin:
+                        only virsh.emulatorpin.positive_testing.get_emulatorpin_parameter.running_guest.emulatorpin_options.live,virsh.emulatorpin.positive_testing.set_emulatorpin_parameter.shutoff_guest.cpulist.emulatorpin_options.config.auto_placement,virsh.emulatorpin.negative_testing.set_emulatorpin_parameter.shutoff_guest.change_emulatorpin.emulatorpin_options.live.excluding
                     - cpu_compare:
                         only virsh.cpu_compare.host_cpu.no_cpu_match.default_feature,virsh.cpu_compare.host_cpu.no_cpu_match.invalid_option
                     - numatune:
@@ -67,13 +69,22 @@ variants:
                         only virsh.nodecpumap.no_option,virsh.nodecpumap.unexpect_option
                     - schedinfo:
                         only virsh.schedinfo_qemu_posix.normal_test.show_schedinfo.valid_domname,virsh.schedinfo_qemu_posix.error_test.invalid_options.none
+                    - setvcpu:
+                        only virsh.setvcpu.normal_test.guest_on.with_comma.with_2_threads.id_option.option_enable_live
+                    - setvcpus:
+                        sockets = 1
+                        cores = 4
+                        threads = 1
+                        only virsh.setvcpus.normal_test.guest_on.id_option.option_live.add,virsh.setvcpus.normal_test.guest_off.option_maximum_config,virsh.setvcpus.error_test.invalid_vcpu_count_max
+                    - guestsmt:
+                        only smt.smt1
                     - delete_guest:
                         only remove_guest.without_disk
 
             - memory:
-                only spapr-vlan
+                only virtio_net
                 only qcow2
-                only scsi
+                only virtio_scsi
                 variants:
                     - import:
                         only unattended_install.import.import.default_install.aio_native
@@ -93,9 +104,9 @@ variants:
                         only remove_guest.without_disk
 
             - network:
-                only spapr-vlan
+                only virtio_net
                 only qcow2
-                only scsi
+                only virtio_scsi
                 variants:
                     - import:
                         only unattended_install.import.import.default_install.aio_native
@@ -139,9 +150,9 @@ variants:
                         only remove_guest.without_disk
 
             - storage:
-                only spapr-vlan
+                only virtio_net
                 only qcow2
-                only scsi
+                only virtio_scsi
                 variants:
                     - import:
                         only unattended_install.import.import.default_install.aio_native
@@ -168,9 +179,9 @@ variants:
                     - delete_guest:
                         only remove_guest.without_disk
             - hotplug:
-                only spapr-vlan
+                only virtio_net
                 only qcow2
-                only scsi
+                only virtio_scsi
                 variants:
                     - import:
                         only unattended_install.import.import.default_install.aio_native
@@ -186,13 +197,18 @@ variants:
                         test_dom_xml = "no"
                         tg_size = 8388608
                         only libvirt_mem.positive_test.hot_plug
+                    - cpu:
+                        sockets = 1
+                        cores = 4
+                        threads = 1
+                        only libvirt_vcpu_plug_unplug.positive_test.vcpu_set.live.vcpu_pin.pin_plug_unplug
                     - delete_guest:
                         only remove_guest.without_disk
 
             - lifecycle:
-                only spapr-vlan
+                only virtio_net
                 only qcow2
-                only scsi
+                only virtio_scsi
                 variants:
                     - import:
                         only unattended_install.import.import.default_install.aio_native
@@ -259,9 +275,9 @@ variants:
                     - delete_guest:
                         only remove_guest.without_disk
             - ras:
-                only spapr-vlan
+                only virtio_net
                 only qcow2
-                only scsi
+                only virtio_scsi
                 variants:
                     - import:
                         only unattended_install.import.import.default_install.aio_native
@@ -274,32 +290,32 @@ variants:
             - boundary:
                 variants:
                     - cpu_max:
-                        only spapr-vlan
+                        only virtio_net
                         only qcow2
-                        only scsi
+                        only virtio_scsi
                         # Memory 10G
                         mem = 10240
-                        smp= 192
-                        vcpu_cores = 24
-                        vcpu_threads = 8
-                        vcpu_sockets = 1
+                        smp = 240
+                        vcpu_cores = 120
+                        vcpu_threads = 1
+                        vcpu_sockets = 2
                         only unattended_install.import.import.default_install.aio_native,remove_guest.without_disk
                     - memory_max:
-                        only spapr-vlan
+                        only virtio_net
                         only qcow2
-                        only scsi
+                        only virtio_scsi
                         # Memory 20G
                         # :TODO: find out max system memory and replace it here
                         mem = 20480
                         smp = 80
-                        vcpu_cores = 10
-                        vcpu_threads = 8
+                        vcpu_cores = 80
+                        vcpu_threads = 1
                         vcpu_sockets = 1
                         only unattended_install.import.import.default_install.aio_native,remove_guest.without_disk
                     - cpu_mem_max:
-                        only spapr-vlan
+                        only virtio_net
                         only qcow2
-                        only scsi
+                        only virtio_scsi
                         # Memory 20G
                         mem = 20480
                         smp = 192
@@ -310,7 +326,7 @@ variants:
                     - network_max:
                         flexible_nic_index = yes
                         only qcow2
-                        only scsi
+                        only virtio_scsi
                         variants:
                             - spaprvlan:
                                 only spapr-vlan
@@ -323,9 +339,9 @@ variants:
                                 only unattended_install.import.import.default_install.aio_native,remove_guest.without_disk
                     - disk:
                         only qcow2
-                        only spapr-vlan
+                        only virtio_net
                         variants:
-                            - ibmscsi:
+                            - ibmvscsi:
                                 only scsi
                                 only unattended_install.import.import.default_install.aio_native,remove_guest.without_disk
                             - virtioscsi:
@@ -336,24 +352,24 @@ variants:
                                 only unattended_install.import.import.default_install.aio_native,remove_guest.without_disk
 
             - stress:
-                only spapr-vlan
+                only virtio_net
                 only qcow2
-                only spapr_vscsi
+                only virtio_scsi
                 variants:
                     - import:
                         only unattended_install.import.import.default_install.aio_native
                     - disk:
-                        only autotest.dbench
+                        only avocado.dbench
                     - cpu:
-                        only autotest.stess
+                        only avocado.stress
                     - delete_guest:
                         only remove_guest.without_disk
 
 
             - backuprestore:
-                only spapr-vlan
+                only virtio_net
                 only qcow2
-                only scsi
+                only virtio_scsi
                 variants:
                     - import:
                         only unattended_install.import.import.default_install.aio_native


### PR DESCRIPTION
1. Added additional tests in cpu area
2. Modified default disk, network type to virtio

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>