### PR TITLE
Run status handling

### DIFF
--- a/avocado-setup.py
+++ b/avocado-setup.py
@@ -95,7 +95,7 @@ class TestSuite():
             self.conf = local_cfg
         return self.conf
 
-    def runstatus(self, status, summary="Tests Executed", link=None):
+    def runstatus(self, status, summary="Tests Executed", link=''):
         self.run = status
         self.runsummary = summary
         self.runlink = link
@@ -654,13 +654,13 @@ if __name__ == '__main__':
                     time.sleep(int(args.interval))
 
         # List the final output
-        summary_output = ["Summary of test results can be found below:\n%-25s %-10s %-85s %-20s" % ('TestSuite', 'Testrun', 'ResultLink', 'Summary')]
-
+        summary_output = ["Summary of test results can be found below:\n%-75s %-10s %-20s" % ('TestSuite', 'TestRun', 'Summary')]
         for test_suite in Testsuites_list:
-            summary_output.append('%-25s %-10s %-85s %-20s' % (Testsuites[test_suite].name,
-                                                               Testsuites[test_suite].run,
-                                                               Testsuites[test_suite].runlink,
-                                                               Testsuites[test_suite].runsummary))
+            summary_output.append(' ')
+            summary_output.append('%-75s %-10s %-20s' % (Testsuites[test_suite].name,
+                                                         Testsuites[test_suite].run,
+                                                         Testsuites[test_suite].runsummary))
+            summary_output.append(Testsuites[test_suite].runlink)
         logger.info("\n".join(summary_output))
 
     if os.path.isdir("/tmp/mux/"):

--- a/avocado-setup.py
+++ b/avocado-setup.py
@@ -384,11 +384,15 @@ def run_test(testsuite, avocado_bin):
 
     try:
         logger.info("Running: %s", cmd)
-        os.system(cmd)
+        status = os.system(cmd)
+        status = int(bin(int(status))[2:].zfill(16)[:-8], 2)
+        if status >= 2:
+            testsuite.runstatus("Not_Run", "Command execution failed")
+            return
     except Exception, error:
         logger.error("Running testsuite %s failed with error\n%s",
                      testsuite.name, error)
-        testsuite.runstatus("Not_Run", "command execution failed")
+        testsuite.runstatus("Not_Run", "Command execution failed")
         return
     logger.info('')
     result_link = "%s/job.log" % testsuite.jobdir()


### PR DESCRIPTION
Few changes to display the run summary in the first line,
and job log in the next line.
This is to take care of improper alignment of the result summary
existing now.

When Avocado Fails, Job Fails, or Avocado gets interrupted,
the test needs to be tagged as Not_Run. This commit takes care of
that.