### PR TITLE
Fix for input file given without config section

### DIFF
--- a/avocado-setup.py
+++ b/avocado-setup.py
@@ -425,6 +425,7 @@ def edit_mux_file(test_config_name, mux_file_path, tmp_mux_path):
             input_dic[input_line[0]] = input_line[1]
     else:
         logger.debug("Section %s not found in input file", test_config_name)
+        shutil.copyfile(mux_file_path, tmp_mux_path)
         return
 
     with open(mux_file_path) as mux_fp:


### PR DESCRIPTION
In some cases, input file can be given, but no config section for
a test cfg.
In such cases, if there are mux files, their path is manipulated
incorrectly.
This commit fixes that.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>