### PR TITLE
shutdown: Adding system_powerdown testcase in sanity suite

### DIFF
--- a/config/tests/guest/libvirt/sanity.cfg
+++ b/config/tests/guest/libvirt/sanity.cfg
@@ -325,6 +325,11 @@ variants:
                         only virsh.itself.normal_test.default_option,virsh.itself.error_test.invalid_cmd
                     - save:
                         only virsh.save.normal_test.id_option.no_option.no_progress,virsh.save.error_test.no_option
+                    - guest_shutdown:
+                        shutdown_method = system_powerdown
+                        shutdown_count = 20
+                        only shutdown
+                        no virsh.shutdown
                     - delete_guest:
                         only remove_guest.without_disk
                     - import:


### PR DESCRIPTION
qemu generic testcase include shutdown using qemu monitor command
to be validated for a bug observed, it is added to sanity suite.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>