### PR TITLE
sanity: set param vm_list to override the default vm name

### DIFF
--- a/config/tests/guest/libvirt/sanity.cfg
+++ b/config/tests/guest/libvirt/sanity.cfg
@@ -308,6 +308,7 @@ variants:
                     - reboot:
                         only virsh.reboot.normal_test.id_option.no_mode,virsh.reboot.error_test.no_option
                     - domstats:
+                        vm_list = ${vms}
                         only virsh.domstats.normal_test.domain_state.active.no_option.specific_domain,virsh.domstats.error_test.extra_option
                     - dompmsuspend:
                         only virsh.dompmsuspend.positive_test.non_acl.mem,virsh.dompmsuspend.negative_test.vm_paused


### PR DESCRIPTION
Test uses default vm name instead of actual vm running in
the env, so lets set it appropriately.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>