### PR TITLE
Add config changes to enable per test profilers

### DIFF
--- a/avocado-setup.py
+++ b/avocado-setup.py
@@ -299,6 +299,9 @@ def create_config(logdir):
     config.add_section('sysinfo.collect')
     config.set('sysinfo.collect', 'enabled', True)
     config.set('sysinfo.collect', 'profiler', True)
+
+    config.add_section('sysinfo.collectibles')
+    config.set('sysinfo.collectibles', 'per_test', True)
     with open(avocado_conf, 'w+') as conf:
         config.write(conf)
 


### PR DESCRIPTION
This is to enable the changes done by the PR:
https://github.com/avocado-framework/avocado/pull/2272
to enable profilers to be run per test by default.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>