### PR TITLE
Modify memory values to run the test successfully

### DIFF
--- a/config/tests/guest/libvirt/sanity.cfg
+++ b/config/tests/guest/libvirt/sanity.cfg
@@ -221,12 +221,10 @@ variants:
                     - change-media:
                         only virsh.change_media.cdrom_test.scsi_.positive_test.eject.none.running_guest
                     - memory:
-                        max_mem_rt = 67108864
-                        max_mem = 33554432
+                        max_mem_rt = 2621440
+                        max_mem = 1048576
                         vcpu = 32
-                        numa_cells = "{'id':'0','cpus':'0-31','memory':'33554432','unit':'KiB'}"
-                        test_dom_xml = "no"
-                        tg_size = 8388608
+                        tg_size = 524288
                         only libvirt_mem.positive_test.hot_plug
                     - cpu:
                         sockets = 1


### PR DESCRIPTION
Modified memory values to run the sanity test successfully
for memory hotplug test.

Signed-off-by: Nageswara R Sastry <rnsastry@linux.vnet.ibm.com>