### PR TITLE
Fix the per_test parameter in config

### DIFF
--- a/avocado-setup.py
+++ b/avocado-setup.py
@@ -299,9 +299,8 @@ def create_config(logdir):
     config.add_section('sysinfo.collect')
     config.set('sysinfo.collect', 'enabled', True)
     config.set('sysinfo.collect', 'profiler', True)
+    config.set('sysinfo.collect', 'per_test', True)
 
-    config.add_section('sysinfo.collectibles')
-    config.set('sysinfo.collectibles', 'per_test', True)
     with open(avocado_conf, 'w+') as conf:
         config.write(conf)
 


### PR DESCRIPTION
Fixed the per_test parameter in config to collect per test.
It was previously in collectibles section, but should be in
collect section.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>