### PR TITLE
Fix per_test parameter to be in sysinfo.collect section

### DIFF
--- a/avocado-setup.py
+++ b/avocado-setup.py
@@ -299,9 +299,8 @@ def create_config(logdir):
     config.add_section('sysinfo.collect')
     config.set('sysinfo.collect', 'enabled', True)
     config.set('sysinfo.collect', 'profiler', True)
+    config.set('sysinfo.collect', 'per_test', True)
 
-    config.add_section('sysinfo.collectibles')
-    config.set('sysinfo.collectibles', 'per_test', True)
     with open(avocado_conf, 'w+') as conf:
         config.write(conf)
 


### PR DESCRIPTION
As per the env/avocado/avocado.conf, per_test should be under sysinfo.collect
https://github.com/avocado-framework/avocado/pull/2272/files#diff-1542c22910c281c76f9ecf2805f2433dR30
per_test = False

Signed-off-by: Harish <harish@linux.vnet.ibm.com>