### PR TITLE
virsh_qemu_attach: add qemu-attach new test case for sanity

### DIFF
--- a/config/tests/guest/libvirt/sanity.cfg
+++ b/config/tests/guest/libvirt/sanity.cfg
@@ -326,6 +326,8 @@ variants:
                         only virsh.itself.normal_test.default_option,virsh.itself.error_test.invalid_cmd
                     - save:
                         only virsh.save.normal_test.id_option.no_option.no_progress,virsh.save.error_test.no_option
+                    - qemu_attach:
+                        only virsh.qemu_attach.normal_test,virsh.qemu_attach.error_test.invalid_pid
                     - guest_shutdown:
                         shutdown_method = system_powerdown
                         shutdown_count = 20


### PR DESCRIPTION
Issue is observed in libvirt using virsh qemu-attach, so
let us add it as part of sanity suite,

https://bugzilla.linux.ibm.com/show_bug.cgi?id=159176

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>