### PR TITLE
qemu_dynamic_ownership: add testcases for dynamic_ownership config

### DIFF
--- a/config/tests/guest/libvirt/sanity.cfg
+++ b/config/tests/guest/libvirt/sanity.cfg
@@ -328,6 +328,9 @@ variants:
                         only virsh.save.normal_test.id_option.no_option.no_progress,virsh.save.error_test.no_option
                     - qemu_attach:
                         only virsh.qemu_attach.normal_test,virsh.qemu_attach.error_test.invalid_pid
+                    - dynamic_ownership:
+                        only powerkvm-libvirt.dac_start_destroy
+                        only no_qemu_usr
                     - guest_shutdown:
                         shutdown_method = system_powerdown
                         shutdown_count = 20


### PR DESCRIPTION
dynamic_ownership config in /etc/libvirt/qemu.conf allows libvirt
to set the user/group DAC ownership on the disk images to match
the uid/gid the QEMU process runs under. we observe bug here, when we
set dynamic_ownership=0, still it permitted vm to boot. This testcase
will help us to validate the regression going forward.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>