### PR TITLE
sanity: virsh_sendkey(lifecycle) testcase fails due to typo in config

### DIFF
--- a/config/tests/guest/libvirt/sanity.cfg
+++ b/config/tests/guest/libvirt/sanity.cfg
@@ -337,7 +337,7 @@ variants:
                         only remove_guest.without_disk
                     - import:
                         display = 'graphic'
-                        vga="std"
+                        vga="standard"
                         only unattended_install.import.import.default_install.aio_native
                     - sendkey:
                         only virsh.sendkey.params_test.non_acl.without_codeset,virsh.sendkey.sysrq.non_acl.show_memory_usage


### PR DESCRIPTION
virsh_sendkey testcase fails due to improper param configuration
caused upon a typo

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>