### PR TITLE
Correct libvirt_mem test case

### DIFF
--- a/config/tests/guest/libvirt/sanity.cfg
+++ b/config/tests/guest/libvirt/sanity.cfg
@@ -227,7 +227,7 @@ variants:
                         numa_cells = "{'id':'0','cpus':'0-31','memory':'33554432','unit':'KiB'}"
                         test_dom_xml = "no"
                         tg_size = 8388608
-                        only libvirt_mem.positive_test.hot_plug
+                        only libvirt_mem.positive_test.memory.hot.plug
                     - cpu:
                         sockets = 1
                         cores = 4


### PR DESCRIPTION
Recent changes to libvirt_mem changed memory hotplug test case
call. Corrected the memory hotplug test case.

libvirt_mem.positive_test.hot_plug changed to the following
libvirt_mem.positive_test.memory.hot.plug

Signed-off-by: Nageswara R Sastry <rnsastry@linux.vnet.ibm.com>