### PR TITLE
sanity: virsh qemu attach fails and it is a WILL_NOT_FIX issue

### DIFF
--- a/config/tests/guest/libvirt/sanity.cfg
+++ b/config/tests/guest/libvirt/sanity.cfg
@@ -326,8 +326,6 @@ variants:
                         only virsh.itself.normal_test.default_option,virsh.itself.error_test.invalid_cmd
                     - save:
                         only virsh.save.normal_test.id_option.no_option.no_progress,virsh.save.error_test.no_option
-                    - qemu_attach:
-                        only virsh.qemu_attach.normal_test,virsh.qemu_attach.error_test.invalid_pid
                     - dynamic_ownership:
                         only powerkvm-libvirt.dac_start_destroy
                         only no_qemu_usr


### PR DESCRIPTION
Fixing it would cause migration to break and the issue is closed
as WILL_NOT_FIX, it is better to remove from regression suite to
avoid known failure.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>