### PR TITLE
Enable one test case from each network_suite for sanity

### DIFF
--- a/config/tests/guest/libvirt/sanity.cfg
+++ b/config/tests/guest/libvirt/sanity.cfg
@@ -152,6 +152,16 @@ variants:
                     - virsh_attach_detach_interface_matrix:
                         only virsh.attach_detach_interface_matrix.pre_vm_state_running.at_option_live.dt_option_live.at_okay_dt_okay
                         only virsh.attach_detach_interface_matrix.pre_vm_state_running.at_option_live.dt_option_config.at_okay_dt_error
+                    - nwfilter_update_lock:
+                        only nwfilter_update_lock
+                    - nwfilter_update_vm_running.update_arp_rule:
+                        only nwfilter_update_vm_running.update_arp_rule
+                    - virsh.domiftune:
+                        only virsh.domiftune.positive_testing.get_domif_parameter.running_guest.options.live
+                    - virsh.domif_setlink_getlink:
+                        only virsh.domif_setlink_getlink.positive_test.interface_mac.with_config.domain_name.running_guest.domif_setlink.setlink_up
+                    - virsh.nwfilter_edit:
+                        only virsh.nwfilter_edit.positive_test.use_uuid
                     - delete_guest:
                         only remove_guest.without_disk
 


### PR DESCRIPTION
Test cases enabled are nwfilter_update_lock, nwfilter_update_vm_running,
virsh.domiftune, virsh.domif_setlink_getlink and virsh.nwfilter_edit

Signed-off-by: Venkat R B <vrbagal1@linux.vnet.ibm.com>