### PR TITLE
Making execution order tests-per-variant default

### DIFF
--- a/avocado-setup.py
+++ b/avocado-setup.py
@@ -571,6 +571,8 @@ if __name__ == '__main__':
         outputdir = os.path.join(BASE_PATH, 'results')
 
     additional_args += ' --job-results-dir %s' % outputdir
+    if '--execution-order' not in additional_args:
+        additional_args += ' --execution-order tests-per-variant'
 
     if (args.bootstrap or need_bootstrap()):
         create_config(outputdir)


### PR DESCRIPTION
It makes more sense to set execution order run tests-per-variant
instead of variant-per-test.
There are more insstances where former is preferred.
So, making it default.
Users can still override it by passing additional args

Example:
tests-per-variant (made default now):
 (1/6) bonding.py:Bonding.test_setup;active-backup-2640: PASS (12.24 s)
 (2/6) bonding.py:Bonding.test_run;active-backup-2640: PASS (88.16 s)
 (3/6) bonding.py:Bonding.test_cleanup;active-backup-2640: PASS (12.31
s)
 (4/6) bonding.py:Bonding.test_setup;802.3ad-1ac4: PASS (11.18 s)
 (5/6) bonding.py:Bonding.test_run;802.3ad-1ac4: PASS (87.23 s)
 (6/6) bonding.py:Bonding.test_cleanup;802.3ad-1ac4: PASS (12.56 s)

variant-per-test:
 (1/6) bonding.py:Bonding.test_setup;actibe-backup-8195: PASS (12.23 s)
 (2/6) bonding.py:Bonding.test_setup;802.3ad-1ac4: ERROR (0.36 s)
 (3/6) bonding.py:Bonding.test_run;actibe-backup-8195: PASS (87.25 s)
 (4/6) bonding.py:Bonding.test_run;802.3ad-1ac4: PASS (88.21 s)
 (5/6) bonding.py:Bonding.test_cleanup;actibe-backup-8195: PASS (12.14
s)
 (6/6) bonding.py:Bonding.test_cleanup;802.3ad-1ac4: ERROR (0.40 s)

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>