### PR TITLE
Added only default tests to memory hotplug

### DIFF
--- a/config/tests/guest/libvirt/sanity.cfg
+++ b/config/tests/guest/libvirt/sanity.cfg
@@ -227,7 +227,7 @@ variants:
                         numa_cells = "{'id':'0','cpus':'0-31','memory':'33554432','unit':'KiB'}"
                         test_dom_xml = "no"
                         tg_size = 8388608
-                        only libvirt_mem.positive_test.memory.hot.plug
+                        only libvirt_mem.positive_test.memory..default
                     - cpu:
                         sockets = 1
                         cores = 4


### PR DESCRIPTION
Added only default test of memory hotplug. Initially the test was
only for hotplug, additionally added hotunplug, coldplug  and
coldunplug too.

Signed-off-by: Hariharan T.S <hari@linux.vnet.ibm.com>