### PR TITLE
Adding a way to specify "not to run" tests

### DIFF
--- a/README
+++ b/README
@@ -281,9 +281,17 @@
          - The user runs the host_sanity suite using the avocado-setup.py script explained in Section 4 above.
          - If the user wishes to run a test with yaml file inputs, the yaml file can be specified in the same line in the cfg file,
          separated by a space. Refer config/tests/host/example.cfg for example.
+
+
+6. NO RUN TEST
+
+    Some tests have the potential of causing system crashes / hangs. Such test in cfg file hinders the run of tests that follow.
+    So, if such tests are identified and need to be "not run" for a particular environment (Since they can run fine on others),
+    we have a provision to mention such tests to not run.
+    Please have a look at "config/wrapper/no_run_test.conf"
+
       
-      
-6. REFERENCE LINKS
+7. REFERENCE LINKS
 
     Avocado Test Framework repositories on GitHub:
       https://github.com/avocado-framework
@@ -298,7 +306,7 @@
       https://github.com/open-power-host-os
 
 
-7. KNOWN ISSUES AND LIMITATION
+8. KNOWN ISSUES AND LIMITATION
 
     Refer to the Issues section of this repository, linked below, for details on bugs, limitations, future enhancements, and investigations:
       https://github.com/open-power-host-os/tests/issues?q=is%3Aopen+is%3Aissue

--- a/avocado-setup.py
+++ b/avocado-setup.py
@@ -28,9 +28,12 @@ from lib.logger import logger_init
 
 BASE_PATH = os.path.dirname(os.path.abspath(__file__))
 CONFIG_PATH = "%s/config/wrapper/env.conf" % BASE_PATH
+NORUNTEST_PATH = "%s/config/wrapper/no_run_tests.conf" % BASE_PATH
 TEST_CONF_PATH = "%s/config/tests/" % BASE_PATH
 CONFIGFILE = ConfigParser.SafeConfigParser()
 CONFIGFILE.read(CONFIG_PATH)
+NORUNTESTFILE = ConfigParser.SafeConfigParser()
+NORUNTESTFILE.read(NORUNTEST_PATH)
 INPUTFILE = ConfigParser.SafeConfigParser()
 INPUTFILE.optionxform = str
 AVOCADO_REPO = CONFIGFILE.get('repo', 'avocado')
@@ -511,12 +514,17 @@ def parse_test_config(test_config_file, avocado_bin):
     if not os.path.isfile(test_config_file):
         logger.error("Test Config %s not present", test_config_file)
     else:
+        env_type = get_env_type()
+        if NORUNTESTFILE.has_section('norun_%s' % env_type):
+            norun_tests = NORUNTESTFILE.get('norun_%s' % env_type, 'tests').split(',')
         with open(test_config_file, 'r') as fp:
             test_config_contents = fp.read()
         test_list = []
         mux_flag = 0
         for line in test_config_contents.splitlines():
             test_dic = {}
+            if line in norun_tests:
+                continue
             if line.startswith("#") or not line:
                 continue
             line = line.split()

--- a/config/wrapper/no_run_tests.conf
+++ b/config/wrapper/no_run_tests.conf
@@ -1,0 +1,45 @@
+# Add tests that you dont want to run as comma separated list, in the particular environment.
+# The tests should be taken from cfg files.
+# The mentioned tests, if present in any cfg file, do not run.
+# You do not want to run "avocado-misc-tests/io/disk/ioping.py avocado-misc-tests/io/disk/ioping.py.data/ioping.yaml"
+# example.cfg contains this test, so it will not run this test.
+# But if there is another cfg which has "avocado-misc-tests/io/disk/ioping.py" test, that will run.
+# Each test-yaml pair is treated as a different test, and test without yaml is treated as a different test, as should be.
+
+
+[norun_centos]
+tests = 
+[norun_ubuntu]
+tests = 
+[norun_ubuntu_pHyp]
+tests = 
+[norun_rhel]
+tests = 
+[norun_rhel_pHyp]
+tests = 
+[norun_rhel8.0]
+tests = 
+[norun_rhel8.0_pHyp]
+tests = 
+[norun_rhelbe]
+tests = 
+[norun_rhelbe_pHyp]
+tests = 
+[norun_fedora]
+tests = 
+[norun_fedora_pHyp]
+tests = 
+[norun_fedorabe]
+tests = 
+[norun_fedorabe_pHyp]
+tests = 
+[norun_sles]
+tests = 
+[norun_sles_pHyp]
+tests = 
+[norun_sles15]
+tests = 
+[norun_sles15_pHyp]
+tests = 
+[norun_slesbe]
+tests = 


### PR DESCRIPTION
Some tests have the potential of causing system crashes / hangs.
Such test in cfg file hinders the run of tests that follow. So,
if such tests are identified and need to be "not run" for a
particular environment (Since they can run fine on others), we
have a provision to mention such tests to not run.

Add tests that you dont want to run as comma separated list, in the
particular environment, in the file config/wrapper/no_run_tests.conf.
The tests should be taken from cfg files.
The mentioned tests, if present in any cfg file, do not run.

Each test-yaml pair is treated as a different test, and test without
yaml is treated as a different test, as should be.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>