### PR TITLE
avocado-setup.py: Adding Python2 and Python3 support

### DIFF
--- a/config/wrapper/env.conf
+++ b/config/wrapper/env.conf
@@ -14,9 +14,9 @@ packages = gcc,python-devel,xz-devel,python-setuptools,libvirt-devel,tcpdump,vir
 [deps_rhel_pHyp]
 packages = gcc,python-devel,xz-devel,python-setuptools,tcpdump,virt-install,numactl,attr,policycoreutils-python
 [deps_rhel8.0]
-packages = gcc,python2-devel,xz-devel,python2-setuptools,libvirt-devel,tcpdump,virt-install,qemu-kvm,libvirt,SLOF,genisoimage,numactl,attr,policycoreutils-python-utils
+packages = gcc,python36-devel,xz-devel,python3-setuptools,libvirt-devel,tcpdump,virt-install,qemu-kvm,libvirt,SLOF,genisoimage,numactl,attr,policycoreutils-python-utils
 [deps_rhel8.0_pHyp]
-packages = gcc,python2-devel,xz-devel,python2-setuptools,tcpdump,virt-install,numactl,attr,policycoreutils-python-utils
+packages = gcc,python36-devel,xz-devel,python3-setuptools,tcpdump,virt-install,numactl,attr,policycoreutils-python-utils
 [deps_rhelbe]
 packages = gcc,python-devel,xz-devel,python-setuptools,libvirt-devel,tcpdump,libvirt,SLOF,genisoimage,numactl
 [deps_rhelbe_pHyp]


### PR DESCRIPTION
This patch adds Python2 and Python3 support.
Python2 tested with avocado-69lts branch
Python3 tested with avodado-69
With out this patch this runs only on Python2 not on
Python3.
Before running the script need to install the modules
namely future and configparser

Signed-off-by: Nageswara R Sastry <rnsastry@linux.vnet.ibm.com>