### PR TITLE
Fixup: Avoid exit for pip uninstall failure

### DIFF
--- a/avocado-setup.py
+++ b/avocado-setup.py
@@ -511,7 +511,6 @@ def env_clean():
             status, output = commands.getstatusoutput(cmd)
             if status != 0:
                 logger.error("%s %s", err_str, output)
-                sys.exit(1)
             logger.debug("%s", output)
         except Exception, error:
             logger.error("%s %s", err_str, error)


### PR DESCRIPTION
First time bootstrap will not have the pip package
installed, So, let's avoid fail in those cases and
proceed installing them.

This patch will avoid below cases.
17:16:56 ERROR   : Error in removing package: avocado Cannot uninstall requirement avocado, not installed
Cannot uninstall requirement avocado, not installed

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>