### PR TITLE
Adding a way to specify execution order per test

### DIFF
--- a/README
+++ b/README
@@ -281,6 +281,8 @@
          - The user runs the host_sanity suite using the avocado-setup.py script explained in Section 4 above.
          - If the user wishes to run a test with yaml file inputs, the yaml file can be specified in the same line in the cfg file,
          separated by a space. Refer config/tests/host/example.cfg for example.
+         - If the user wishes to run a test with yaml by specifying execution order, the order {tests-per-variant,variants-per-test}
+         can be specified in the same line, after yaml, separated by a space
 
 
 6. NO RUN TEST

--- a/config/tests/host/example.cfg
+++ b/config/tests/host/example.cfg
@@ -1,1 +1,2 @@
-avocado-misc-tests/io/disk/ioping.py avocado-misc-tests/io/disk/ioping.py.data/ioping.yaml
+avocado-misc-tests/io/disk/ioping.py avocado-misc-tests/io/disk/ioping.py.data/ioping.yaml tests-per-variant
+avocado-misc-tests/io/disk/fs_mark.py avocado-misc-tests/io/disk/fs_mark.py.data/fs_mark.yaml


### PR DESCRIPTION
In avocado, execution order can be either tests-per-variant or
variants-per-test.
Test suite (cfg file) can have combination of tests, each of
which can prefer either one of the orders.

So, introducing a way to have per test configuration of execution
order.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>