### PR TITLE
Fixup: Avoid selecting wrong package for attr

### DIFF
--- a/config/wrapper/env.conf
+++ b/config/wrapper/env.conf
@@ -4,19 +4,19 @@ avocado_vt = https://github.com/avocado-framework/avocado-vt.git
 tests = https://github.com/avocado-framework-tests/avocado-misc-tests.git
 
 [deps_centos]
-packages = gcc,python-devel,p7zip,python-setuptools,python-stevedore,libvirt-devel,tcpdump,virt-install,qemu,libvirt,SLOF,genisoimage,numactl,attr,policycoreutils-python
+packages = gcc,python-devel,p7zip,python-setuptools,python-stevedore,libvirt-devel,tcpdump,virt-install,qemu,libvirt,SLOF,genisoimage,numactl,^attr,policycoreutils-python
 [deps_ubuntu]
-packages = gcc,python-dev,p7zip,python-setuptools,libvirt-dev,tcpdump,numactl,libosinfo-1.0-0,attr,libvirt-bin
+packages = gcc,python-dev,p7zip,python-setuptools,libvirt-dev,tcpdump,numactl,libosinfo-1.0-0,^attr,libvirt-bin
 [deps_ubuntu_pHyp]
-packages = gcc,python-dev,p7zip,python-setuptools,tcpdump,numactl,libosinfo-1.0-0,attr
+packages = gcc,python-dev,p7zip,python-setuptools,tcpdump,numactl,libosinfo-1.0-0,^attr
 [deps_rhel]
-packages = gcc,python-devel,xz-devel,python-setuptools,libvirt-devel,tcpdump,virt-install,qemu,libvirt,SLOF,genisoimage,numactl,attr,policycoreutils-python
+packages = gcc,python-devel,xz-devel,python-setuptools,libvirt-devel,tcpdump,virt-install,qemu,libvirt,SLOF,genisoimage,numactl,^attr,policycoreutils-python
 [deps_rhel_pHyp]
-packages = gcc,python-devel,xz-devel,python-setuptools,tcpdump,virt-install,numactl,attr,policycoreutils-python
+packages = gcc,python-devel,xz-devel,python-setuptools,tcpdump,virt-install,numactl,^attr,policycoreutils-python
 [deps_rhel8.0]
-packages = gcc,python2-devel,xz-devel,python2-setuptools,libvirt-devel,tcpdump,virt-install,qemu-kvm,libvirt,SLOF,genisoimage,numactl,attr,policycoreutils-python-utils
+packages = gcc,python2-devel,xz-devel,python2-setuptools,libvirt-devel,tcpdump,virt-install,qemu-kvm,libvirt,SLOF,genisoimage,numactl,^attr,policycoreutils-python-utils
 [deps_rhel8.0_pHyp]
-packages = gcc,python2-devel,xz-devel,python2-setuptools,tcpdump,virt-install,numactl,attr,policycoreutils-python-utils
+packages = gcc,python2-devel,xz-devel,python2-setuptools,tcpdump,virt-install,numactl,^attr,policycoreutils-python-utils
 [deps_rhelbe]
 packages = gcc,python-devel,xz-devel,python-setuptools,libvirt-devel,tcpdump,libvirt,SLOF,genisoimage,numactl
 [deps_rhelbe_pHyp]


### PR DESCRIPTION
Let's make the search pattern more refined to select attr
package as we happen to choose the wrong one, leaving it
to crash the wrapper later.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>