### PR TITLE
Fixup: Move pip install custom packages to bootstrap

### DIFF
--- a/avocado-setup.py
+++ b/avocado-setup.py
@@ -156,7 +156,6 @@ def env_check(disable_kvm):
             logger.error("Please install following "
                          "dependancy packages %s", " ".join(not_found))
             sys.exit(1)
-    pip_install()
 
 
 def is_avocado_plugin_avl(plugin):
@@ -307,6 +306,7 @@ def bootstrap(disable_kvm=False):
     :params disable_kvm: Flag to disable kvm environment bootstrap
     """
     env_clean()
+    pip_install()
     logger.info("Bootstrapping Avocado")
     get_repo(AVOCADO_REPO, BASE_PATH, True)
     if not disable_kvm:


### PR DESCRIPTION
Let's not try to install custom python packages on
every run and do it only when bootstrap.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>