### PR TITLE
Adding a way to specify execution order per test

### DIFF
--- a/README
+++ b/README
@@ -281,6 +281,8 @@
          - The user runs the host_sanity suite using the avocado-setup.py script explained in Section 4 above.
          - If the user wishes to run a test with yaml file inputs, the yaml file can be specified in the same line in the cfg file,
          separated by a space. Refer config/tests/host/example.cfg for example.
+         - If the user wishes to run a test with yaml by specifying execution order, the order {tests-per-variant,variants-per-test}
+         can be specified in the same line, after yaml, separated by a space.
 
 
 6. NO RUN TEST

--- a/avocado-setup.py
+++ b/avocado-setup.py
@@ -49,7 +49,7 @@ class TestSuite():
     guest_add_args = ""
     host_add_args = ""
 
-    def __init__(self, name, resultdir, vt_type, test=None, mux=None):
+    def __init__(self, name, resultdir, vt_type, test=None, mux=None, args=None):
         self.id = binascii.b2a_hex(os.urandom(20))
         self.name = str(name)
         self.shortname = "_".join(self.name.split('_')[1:])
@@ -59,6 +59,7 @@ class TestSuite():
         self.conf = None
         self.test = test
         self.mux = mux
+        self.args = args
         self.run = "Not_Run"
         self.runsummary = None
         self.runlink = None
@@ -340,6 +341,8 @@ def run_test(testsuite, avocado_bin):
         if testsuite.mux:
             cmd += " -m %s" % os.path.join(TEST_DIR, testsuite.mux)
         cmd += " --force-job-id %s %s" % (testsuite.id, TestSuite.host_add_args)
+        if testsuite.args:
+            cmd += testsuite.args
 
     try:
         logger.info("Running: %s", cmd)
@@ -453,6 +456,8 @@ def parse_test_config(test_config_file, avocado_bin, disable_kvm):
                     tmp_mux_path = os.path.join('/tmp/mux/', "%s_%s.yaml" % (test_config_name, test_dic['name']))
                     edit_mux_file(test_config_name, mux_file, tmp_mux_path)
                     test_dic['mux'] = tmp_mux_path
+            if len(line) > 2:
+                test_dic['args'] = " --execution-order %s " % line[2]
             test_list.append(test_dic)
         if mux_flag == 0:
             single_test_dic = {}
@@ -609,12 +614,14 @@ if __name__ == '__main__':
                                                      "Config file not present")
                     continue
                 for test in test_list:
-                    if not test.has_key('mux'):
-                        test['mux'] = ''
+                    for l_key in ['mux', 'args']:
+                        if not test.has_key(l_key):
+                            test[l_key] = ''
                     test_suite_name = "%s_%s" % (test_suite, test['name'])
                     Testsuites[test_suite_name] = TestSuite(test_suite_name,
                                                             outputdir, args.vt_type,
-                                                            test['test'], test['mux'])
+                                                            test['test'], test['mux'],
+                                                            test['args'])
                     Testsuites_list.append(test_suite_name)
 
             if 'guest' in test_suite:

--- a/config/tests/host/example.cfg
+++ b/config/tests/host/example.cfg
@@ -1,1 +1,2 @@
-avocado-misc-tests/io/disk/ioping.py avocado-misc-tests/io/disk/ioping.py.data/ioping.yaml
+avocado-misc-tests/io/disk/ioping.py avocado-misc-tests/io/disk/ioping.py.data/ioping.yaml tests-per-variant
+avocado-misc-tests/io/disk/fs_mark.py avocado-misc-tests/io/disk/fs_mark.py.data/fs_mark.yaml


### PR DESCRIPTION
In avocado, execution order can be either tests-per-variant or
variants-per-test.
Test suite (cfg file) can have combination of tests, each of
which can prefer either one of the orders.

So, introducing a way to have per test configuration of execution
order.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>