### PR TITLE
Fix for norun_tests not found in an environment

### DIFF
--- a/avocado-setup.py
+++ b/avocado-setup.py
@@ -419,6 +419,7 @@ def parse_test_config(test_config_file, avocado_bin, disable_kvm):
         logger.error("Test Config %s not present", test_config_file)
     else:
         (env_ver, env_type, cmdpat) = helper.get_env_type(disable_kvm)
+        norun_tests = []
         if NORUNTESTFILE.has_section('norun_%s_%s' % (env_ver, env_type)):
             norun_tests = NORUNTESTFILE.get('norun_%s_%s' % (env_ver, env_type), 'tests').split(',')
         with open(test_config_file, 'r') as fp:

--- a/config/wrapper/no_run_tests.conf
+++ b/config/wrapper/no_run_tests.conf
@@ -8,38 +8,75 @@
 
 
 [norun_centos]
-tests = 
+tests =
+[norun_centos_NV]
+tests =
+[norun_centos_pHyp]
+tests =
+[norun_centos_kvm]
+tests =
 [norun_ubuntu]
-tests = 
+tests =
+[norun_ubuntu_NV]
+tests =
 [norun_ubuntu_pHyp]
-tests = 
+tests =
+[norun_ubuntu_kvm]
+tests =
 [norun_rhel]
-tests = 
+tests =
+[norun_rhel_NV]
+tests =
 [norun_rhel_pHyp]
-tests = 
+tests =
+[norun_rhel_kvm]
+tests =
 [norun_rhel8.0]
-tests = 
+tests =
+[norun_rhel8.0_NV]
+tests =
 [norun_rhel8.0_pHyp]
-tests = 
-[norun_rhelbe]
-tests = 
-[norun_rhelbe_pHyp]
-tests = 
+tests =
+[norun_rhel8.0_kvm]
+tests =
+tests =
 [norun_fedora]
-tests = 
+tests =
+[norun_fedora_NV]
+tests =
 [norun_fedora_pHyp]
-tests = 
+tests =
+[norun_fedora_kvm]
+tests =
 [norun_fedorabe]
-tests = 
+tests =
+[norun_fedorabe_NV]
+tests =
 [norun_fedorabe_pHyp]
-tests = 
+tests =
+[norun_fedorabe_kvm]
+tests =
 [norun_sles]
-tests = 
+tests =
+[norun_sles_NV]
+tests =
 [norun_sles_pHyp]
-tests = 
+tests =
+[norun_sles_kvm]
+tests =
 [norun_sles15]
-tests = 
+tests =
+[norun_sles15_NV]
+tests =
 [norun_sles15_pHyp]
-tests = 
+tests =
+[norun_sles15_kvm]
+tests =
 [norun_slesbe]
-tests = 
+tests =
+[norun_slesbe_NV]
+tests =
+[norun_slesbe_pHyp]
+tests =
+[norun_slesbe_kvm]
+tests =


### PR DESCRIPTION
We get an error in case there is no norun_<env> found in
norun_tests conf.
This is fixed by handling it when not available in the wrapper.

We actually had discovered this error since there was a refactor
in the environment, and had missed norun_tests in the process.

So, this patch takes care of fixing it in both the places.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>
Reported-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>