### PR TITLE
Fix pci library when wwids does not exist

### DIFF
--- a/lib/pci.py
+++ b/lib/pci.py
@@ -127,6 +127,8 @@ def get_multipath_wwids(disks_list):
             if disk == line.split()[-2] and line.split()[-1] != '-':
                 wwid_list.append(line.split()[-1])
     existing_wwids = []
+    if not os.path.isfile("/etc/multipath/wwids"):
+        return []
     with open('/etc/multipath/wwids', 'r') as wwid_file:
         for line in wwid_file:
             if '#' not in line:


### PR DESCRIPTION
When /etc/multipath/wwids does not exist, ie, no multipath disks
available in the system, the library errors out.
Handled that via this commit.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>