### PR TITLE
wrapper/env.conf: add dependency packages for Ubuntu

### DIFF
--- a/config/wrapper/env.conf
+++ b/config/wrapper/env.conf
@@ -18,7 +18,7 @@ packages =
 [deps_ubuntu_pHyp]
 packages =
 [deps_ubuntu_kvm]
-packages = p7zip,libvirt-dev,tcpdump,libosinfo-1.0-0,attr,libvirt-bin
+packages = p7zip,libvirt-dev,tcpdump,libosinfo-1.0-0,attr,libvirt-bin,arping,nfs-kernel-server,virtinst
 [deps_rhel]
 packages = gcc,python-devel,xz-devel,python-setuptools,numactl,policycoreutils-python
 [deps_rhel_NV]


### PR DESCRIPTION
For using Avocado-VT tests in Ubuntu KVM host, we would require
arping, virtinst and nfs-kernel-server packages as dependencies.

Signed-off-by: Balamuruhan S <bala24@linux.vnet.ibm.com>