### PR TITLE
Refactor package selection based on major version

### DIFF
--- a/avocado-setup.py
+++ b/avocado-setup.py
@@ -128,8 +128,14 @@ def env_check(disable_kvm):
         os.makedirs("/tmp/mux/")
     not_found = []
     (env_ver, env_type, cmd_pat) = helper.get_env_type(disable_kvm)
-    # try to check base packages
+    # try to check base packages using major version numbers
+    env_ver = env_ver.split('.')[0]
     env_deps = []
+    if not CONFIGFILE.has_section('deps_%s' % env_ver):
+        # Fallback to base name if specific version is not found
+        dist = helper.get_dist()
+        env_ver = dist[0]
+
     if CONFIGFILE.has_section('deps_%s' % env_ver):
         packages = CONFIGFILE.get('deps_%s' % env_ver, 'packages')
         if packages != '':

--- a/config/wrapper/env.conf
+++ b/config/wrapper/env.conf
@@ -19,6 +19,14 @@ packages =
 packages =
 [deps_ubuntu_kvm]
 packages = p7zip,libvirt-dev,tcpdump,libosinfo-1.0-0,attr,libvirt-bin,arping,nfs-kernel-server,virtinst
+[deps_ubuntu18]
+packages = gcc,python-dev,python-setuptools,numactl
+[deps_ubuntu18_NV]
+packages =
+[deps_ubuntu18_pHyp]
+packages =
+[deps_ubuntu18_kvm]
+packages = p7zip,libvirt-dev,tcpdump,libosinfo-1.0-0,attr,libvirt-bin,arping,nfs-kernel-server,virtinst
 [deps_rhel]
 packages = gcc,python-devel,xz-devel,python-setuptools,numactl,policycoreutils-python
 [deps_rhel_NV]
@@ -27,13 +35,21 @@ packages =
 packages =
 [deps_rhel_kvm]
 packages = p7zip,libvirt-devel,tcpdump,virt-install,qemu,libvirt,SLOF,genisoimage,^attr
-[deps_rhel8.0]
+[deps_rhel7]
+packages = gcc,python-devel,xz-devel,python-setuptools,numactl,policycoreutils-python
+[deps_rhel7_NV]
+packages =
+[deps_rhel7_pHyp]
+packages =
+[deps_rhel7_kvm]
+packages = p7zip,libvirt-devel,tcpdump,virt-install,qemu,libvirt,SLOF,genisoimage,^attr
+[deps_rhel8]
 packages = gcc,python2-devel,xz-devel,python2-setuptools,numactl,policycoreutils-python-utils
-[deps_rhel8.0_NV]
+[deps_rhel8_NV]
 packages =
-[deps_rhel8.0_pHyp]
+[deps_rhel8_pHyp]
 packages =
-[deps_rhel8.0_kvm]
+[deps_rhel8_kvm]
 packages = libvirt-devel,tcpdump,virt-install,qemu-kvm,libvirt,SLOF,genisoimage,^attr
 [deps_rhelbe]
 packages = gcc,python-devel,xz-devel,python-setuptools,numactl
@@ -43,6 +59,14 @@ packages =
 packages =
 [deps_rhelbe_pHyp]
 packages =
+[deps_rhelbe7]
+packages = gcc,python-devel,xz-devel,python-setuptools,numactl
+[deps_rhelbe7_NV]
+packages =
+[deps_rhelbe7_pHyp]
+packages =
+[deps_rhelbe7_pHyp]
+packages =
 [deps_fedora]
 packages = gcc,python2-devel,xz-devel,python2-setuptools,numactl
 [deps_fedora_NV]
@@ -50,6 +74,14 @@ packages =
 [deps_fedora_pHyp]
 packages =
 [deps_fedora_kvm]
+packages = libvirt-devel,tcpdump,libvirt,SLOF,genisoimage
+[deps_fedora28]
+packages = gcc,python2-devel,xz-devel,python2-setuptools,numactl
+[deps_fedora28_NV]
+packages =
+[deps_fedora28_pHyp]
+packages =
+[deps_fedora28_kvm]
 packages = libvirt-devel,tcpdump,libvirt,SLOF,genisoimage
 [deps_fedorabe]
 packages = gcc,python2-devel,xz-devel,python2-setuptools,numactl
@@ -59,6 +91,14 @@ packages =
 packages =
 [deps_fedorabe_kvm]
 packages = libvirt-devel,tcpdump,libvirt,SLOF,genisoimage
+[deps_fedorabe28]
+packages = gcc,python2-devel,xz-devel,python2-setuptools,numactl
+[deps_fedorabe28_NV]
+packages =
+[deps_fedorabe28_pHyp]
+packages =
+[deps_fedorabe28_kvm]
+packages = libvirt-devel,tcpdump,libvirt,SLOF,genisoimage
 [deps_sles]
 packages = gcc,python-devel,xz-devel,python-setuptools,numactl
 [deps_sles_NV]
@@ -66,6 +106,14 @@ packages =
 [deps_sles_pHyp]
 packages =
 [deps_sles_kvm]
+packages = tcpdump,qemu,p7zip
+[deps_sles12]
+packages = gcc,python-devel,xz-devel,python-setuptools,numactl
+[deps_sles12_NV]
+packages =
+[deps_sles12_pHyp]
+packages =
+[deps_sles12_kvm]
 packages = tcpdump,qemu,p7zip
 [deps_sles15]
 packages = gcc,python-devel,p7zip,xz-devel,python2-setuptools,numactl
@@ -82,6 +130,14 @@ packages =
 [deps_slesbe_pHyp]
 packages =
 [deps_slesbe_kvm]
+packages =
+[deps_slesbe12]
+packages = gcc,python-devel,xz-devel,python-setuptools,tcpdump,numactl
+[deps_slesbe12_NV]
+packages =
+[deps_slesbe12_pHyp]
+packages =
+[deps_slesbe12_kvm]
 packages =
 
 [plugins]

--- a/config/wrapper/no_run_tests.conf
+++ b/config/wrapper/no_run_tests.conf
@@ -7,15 +7,11 @@
 # Each test-yaml pair is treated as a different test, and test without yaml is treated as a different test, as should be.
 
 
-[norun_centos]
-tests =
 [norun_centos_NV]
 tests =
 [norun_centos_pHyp]
 tests =
 [norun_centos_kvm]
-tests =
-[norun_ubuntu]
 tests =
 [norun_ubuntu_NV]
 tests =
@@ -23,15 +19,11 @@ tests =
 tests =
 [norun_ubuntu_kvm]
 tests =
-[norun_rhel]
+[norun_rhel7.7_NV]
 tests =
-[norun_rhel_NV]
+[norun_rhel7.7_pHyp]
 tests =
-[norun_rhel_pHyp]
-tests =
-[norun_rhel_kvm]
-tests =
-[norun_rhel8.0]
+[norun_rhel7.7_kvm]
 tests =
 [norun_rhel8.0_NV]
 tests =
@@ -39,8 +31,11 @@ tests =
 tests =
 [norun_rhel8.0_kvm]
 tests =
+[norun_rhel8.1_NV]
 tests =
-[norun_fedora]
+[norun_rhel8.1_pHyp]
+tests =
+[norun_rhel8.1_kvm]
 tests =
 [norun_fedora_NV]
 tests =
@@ -48,31 +43,23 @@ tests =
 tests =
 [norun_fedora_kvm]
 tests =
-[norun_fedorabe]
-tests =
 [norun_fedorabe_NV]
 tests =
 [norun_fedorabe_pHyp]
 tests =
 [norun_fedorabe_kvm]
 tests =
-[norun_sles]
+[norun_sles12.sp4_NV]
 tests =
-[norun_sles_NV]
+[norun_sles12.sp4_pHyp]
 tests =
-[norun_sles_pHyp]
+[norun_sles12.sp4_kvm]
 tests =
-[norun_sles_kvm]
+[norun_sles15.sp1_NV]
 tests =
-[norun_sles15]
+[norun_sles15.sp1_pHyp]
 tests =
-[norun_sles15_NV]
-tests =
-[norun_sles15_pHyp]
-tests =
-[norun_sles15_kvm]
-tests =
-[norun_slesbe]
+[norun_sles15.sp1_kvm]
 tests =
 [norun_slesbe_NV]
 tests =

--- a/lib/helper.py
+++ b/lib/helper.py
@@ -76,11 +76,12 @@ def get_dist():
             elif line.startswith("VERSION="):
                 try:
                     line = line.replace('"', '')
-                    dist_ver = re.findall("VERSION=(\S+)", line)[0]
-                    dist_ver = re.match('(\d*)(\.)*(\d+)', dist_ver).group()
+                    dist_ver = re.findall("VERSION=(\S+)", line)[0].lower().replace("-",".")
                 except:
                     pass
         fd.close()
+    if os.uname()[-1] == 'ppc64':
+        dist += 'be'
     return (dist, dist_ver)
 
 
@@ -107,12 +108,7 @@ def get_env_type(disable_kvm=False):
     """
     (dist, dist_ver) = get_dist()
     env_ver = dist
-    if os.uname()[-1] == 'ppc64':
-        env_ver += 'be'
-    if dist == "sles" and dist_ver == "15":
-        env_ver += dist_ver
-    elif dist == "rhel" and dist_ver == "8.0":
-        env_ver += dist_ver
+    env_ver += dist_ver
     env_type = get_machine_type()
     if env_type == "NV" and not disable_kvm:
         env_type = "kvm"


### PR DESCRIPTION
This patch provides way to select packages based on major version of a distribution (which does not change often). It also falls back to the package with base name if the running major version is
not handled.

i.e
rhel7.6 & rhel7.7
rhel8.0 & rhel8.1
sles15 & sles15.sp1

All pair use similar list of packages.

When run on a "rhel6" environment it falls back to "rhel".

As for the norun configuration, it uses the combination of major and minor version number so that it is precise to a current test release target.

Signed-off-by: Harish <harish@linux.vnet.ibm.com>