### PR TITLE
Use -q to check exact package name

### DIFF
--- a/config/wrapper/env.conf
+++ b/config/wrapper/env.conf
@@ -10,7 +10,7 @@ packages =
 [deps_centos_pHyp]
 packages =
 [deps_centos_kvm]
-packages = p7zip,libvirt-devel,tcpdump,virt-install,qemu,libvirt,SLOF,genisoimage,^attr
+packages = p7zip,libvirt-devel,tcpdump,virt-install,qemu,libvirt,SLOF,genisoimage,attr
 [deps_ubuntu]
 packages = gcc,python-dev,python-setuptools,numactl
 [deps_ubuntu_NV]
@@ -34,7 +34,7 @@ packages =
 [deps_rhel_pHyp]
 packages =
 [deps_rhel_kvm]
-packages = p7zip,libvirt-devel,tcpdump,virt-install,qemu,libvirt,SLOF,genisoimage,^attr
+packages = p7zip,libvirt-devel,tcpdump,virt-install,qemu,libvirt,SLOF,genisoimage,attr
 [deps_rhel7]
 packages = gcc,python-devel,xz-devel,python-setuptools,numactl,policycoreutils-python
 [deps_rhel7_NV]
@@ -42,7 +42,7 @@ packages =
 [deps_rhel7_pHyp]
 packages =
 [deps_rhel7_kvm]
-packages = p7zip,libvirt-devel,tcpdump,virt-install,qemu,libvirt,SLOF,genisoimage,^attr
+packages = p7zip,libvirt-devel,tcpdump,virt-install,qemu,libvirt,SLOF,genisoimage,attr
 [deps_rhel8]
 packages = gcc,python2-devel,xz-devel,python2-setuptools,numactl,policycoreutils-python-utils
 [deps_rhel8_NV]
@@ -50,7 +50,7 @@ packages =
 [deps_rhel8_pHyp]
 packages =
 [deps_rhel8_kvm]
-packages = libvirt-devel,tcpdump,virt-install,qemu-kvm,libvirt,SLOF,genisoimage,^attr
+packages = libvirt-devel,tcpdump,virt-install,qemu-kvm,libvirt,SLOF,genisoimage,attr
 [deps_rhelbe]
 packages = gcc,python-devel,xz-devel,python-setuptools,numactl
 [deps_rhelbe_NV]

--- a/lib/helper.py
+++ b/lib/helper.py
@@ -115,7 +115,7 @@ def get_env_type(disable_kvm=False):
     if 'ubuntu' in dist:
         cmd_pat = "dpkg -l|grep  ' %s'"
     else:
-        cmd_pat = "rpm -qa|grep %s"
+        cmd_pat = "rpm -q %s"
     return (env_ver, env_type, cmd_pat)
 
 


### PR DESCRIPTION
On few occasions script tries to grep for packages and returns success even with partial match. This patch fixes it by checking the exact package name.

eg.
libgcc_s1-8.2.1+r264010-1.3.7.ppc64le

Without patch:
07:13:21 INFO    : Check for environment
07:13:21 INFO    : Creating temporary mux dir
07:13:27 INFO    : Removing temporary mux dir

With patch:
07:13:54 INFO    : Check for environment
07:13:54 INFO    : Creating temporary mux dir
07:13:55 ERROR   : Please install following dependancy packages gcc

Signed-off-by: Harish <harish@linux.vnet.ibm.com>