### PR TITLE
Fix job.log path in results

### DIFF
--- a/avocado-setup.py
+++ b/avocado-setup.py
@@ -69,9 +69,9 @@ class TestSuite():
             self.vt_type = None
 
     def jobdir(self):
-        cmd = 'grep %s %s/*/id|grep job-' % (self.id, self.resultdir)
+        cmd = 'grep %s %s/*/id|grep job-|cut -d":" -f1' % (self.id, self.resultdir)
         self.job_dir = helper.runcmd(cmd)[1]
-        return self.job_dir
+        return os.path.dirname(self.job_dir)
 
     def config(self):
         if self.type == 'guest':


### PR DESCRIPTION
job.log path was computed with id, which is wrong.
Fixing it.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>