### PR TITLE
Fixed issue in  avocado-setup

### DIFF
--- a/avocado-setup.py
+++ b/avocado-setup.py
@@ -313,7 +313,6 @@ def bootstrap(disable_kvm=False):
     :params disable_kvm: Flag to disable kvm environment bootstrap
     """
     env_clean()
-    pip_install()
     logger.info("Bootstrapping Avocado")
     get_repo(AVOCADO_REPO, BASE_PATH, True)
     if not disable_kvm:


### PR DESCRIPTION
fixed issue in setup.py as pip package (binary) is not avilable on
rhel7 and sles12  distro by default so it failed to continue to test run
and there is no  issue while running avocado as not needed those packages

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>