### PR TITLE
Changing disable-kvm to enable-kvm [PowerNV Tested, PoweVM Yet to, KVM Yet to]

### DIFF
--- a/README
+++ b/README
@@ -88,6 +88,7 @@
       --no-deps-check             Force wrapper to skip check for dependancy packages
       --install-deps              To force wrapper to install dependancy packages (Only for Ubuntu, SLES and yum based OS)
       --clean                     Remove/Uninstall autotest and avocado from system after test completion
+      --enable-kvm                To enable bootstrap kvm tests
 
 
     ARGUMENT DETAILS:

--- a/lib/helper.py
+++ b/lib/helper.py
@@ -102,7 +102,7 @@ def get_machine_type():
     return machine_type
 
 
-def get_env_type(disable_kvm=False):
+def get_env_type(enable_kvm=False):
     """
     Return what environment the system is: Distro, Version, Type
     """
@@ -110,7 +110,7 @@ def get_env_type(disable_kvm=False):
     env_ver = dist
     env_ver += dist_ver
     env_type = get_machine_type()
-    if env_type == "NV" and not disable_kvm:
+    if env_type == "NV" and enable_kvm:
         env_type = "kvm"
     if 'ubuntu' in dist:
         cmd_pat = "dpkg -l|grep  ' %s'"


### PR DESCRIPTION
Default behaviour on PowerNV systems was to assume it is kvm.
This commit changes that assumption to powernv. So, to enable
kvm bootstrap, use option --enable-kvm.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>