### PR TITLE
avocado-setup.py:Modified minor and minor_env variable

### DIFF
--- a/avocado-setup.py
+++ b/avocado-setup.py
@@ -440,8 +440,9 @@ def parse_test_config(test_config_file, avocado_bin, enable_kvm):
         # Get common set of not needed tests
         dist = 'norun_%s' % helper.get_dist()[0]
         major = 'norun_%s' % env_ver.split('.')[0]
-        minor = 'norun_%s_%s' % (env_ver, env_type)
-        for section in [dist, major, minor]:
+        minor = 'norun_%s' % env_ver
+        minor_env = 'norun_%s_%s' % (env_ver, env_type)
+        for section in [dist, major, minor, minor_env]:
             if NORUNTESTFILE.has_section(section):
                 norun_tests.extend(NORUNTESTFILE.get(section, 'tests').split(','))
 

--- a/config/wrapper/no_run_tests.conf
+++ b/config/wrapper/no_run_tests.conf
@@ -27,6 +27,16 @@ tests =
 tests =
 [norun_rhel7]
 tests =
+[norun_rhel7.6]
+tests =
+[norun_rhel7.6_NV]
+tests =
+[norun_rhel7.6_pHyp]
+tests =
+[norun_rhel7.6_kvm]
+tests =
+[norun_rhel7.7]
+tests =
 [norun_rhel7.7_NV]
 tests =
 [norun_rhel7.7_pHyp]
@@ -35,11 +45,15 @@ tests =
 tests =
 [norun_rhel8]
 tests =
+[norun_rhel8.0]
+tests =
 [norun_rhel8.0_NV]
 tests =
 [norun_rhel8.0_pHyp]
 tests =
 [norun_rhel8.0_kvm]
+tests =
+[norun_rhel8.1]
 tests =
 [norun_rhel8.1_NV]
 tests =
@@ -65,13 +79,33 @@ tests =
 tests =
 [norun_sles12]
 tests =
+[norun_sles12.sp3]
+tests =
+[norun_sles12.sp3_NV]
+tests =
+[norun_sles12.sp3_pHyp]
+tests =
+[norun_sles12.sp3_kvm]
+tests =
+[norun_sles12.sp4]
+tests =
 [norun_sles12.sp4_NV]
 tests =
 [norun_sles12.sp4_pHyp]
 tests =
 [norun_sles12.sp4_kvm]
 tests =
+[norun_sles12.sp5]
+tests =
+[norun_sles12.sp5_NV]
+tests =
+[norun_sles12.sp5_pHyp]
+tests =
+[norun_sles12.sp5_kvm]
+tests =
 [norun_sles15]
+tests =
+[norun_sles15.sp1]
 tests =
 [norun_sles15.sp1_NV]
 tests =


### PR DESCRIPTION
config/wrapper/no_run_tests.conf:Added sample configurations for
some distros

Previously along with version we have machine type. Now I made
changes in order to differentiate version and version with machine
type

Signed-off-by: Shirisha Ganta <shiganta@in.ibm.com>