### PR TITLE
Fixing host additional arguments

### DIFF
--- a/avocado-setup.py
+++ b/avocado-setup.py
@@ -628,6 +628,7 @@ if __name__ == '__main__':
                                             "%s"' % args.no_filter
             if additional_args:
                 TestSuite.guest_add_args += additional_args
+        if "host_" in args.run_suite:
             TestSuite.host_add_args = additional_args
         test_suites = args.run_suite.split(',')
         if args.install_guest:


### PR DESCRIPTION
This was caused by a missing if block on host tests due to another
commit 6a61f1856778384f5f1c7bcabf4e90993f28b59e.
Fixing with this commit.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>