### PR TITLE
config/wrapper/env.conf: Remove duplicates

### DIFF
--- a/config/wrapper/env.conf
+++ b/config/wrapper/env.conf
@@ -57,13 +57,9 @@ packages = gcc,python-devel,xz-devel,python-setuptools,numactl
 packages =
 [deps_rhelbe_pHyp]
 packages =
-[deps_rhelbe_pHyp]
-packages =
 [deps_rhelbe7]
 packages = gcc,python-devel,xz-devel,python-setuptools,numactl
 [deps_rhelbe7_NV]
-packages =
-[deps_rhelbe7_pHyp]
 packages =
 [deps_rhelbe7_pHyp]
 packages =


### PR DESCRIPTION
With python3 configparser detects duplicates and throws

configparser.DuplicateSectionError: While reading from '/home/tests/config/wrapper/env.conf' [line 60]: section 'deps_rhelbe_pHyp' already exists

Patch fixes it.

Signed-off-by: Harish <harish@linux.ibm.com>