### PR TITLE
Handle user defined test repo tags

### DIFF
--- a/avocado-setup.py
+++ b/avocado-setup.py
@@ -233,6 +233,8 @@ def get_repo(repo, basepath, install=False):
     """
     repo_name = repo.split('/')[-1].split('.')[0]
     repo_path = os.path.join(basepath, repo_name)
+    if os.path.isdir(repo_path) and ('-b ' or '--branch ' in repo):
+        shutil.rmtree(repo_path)
     if os.path.isdir(repo_path):
         cmd = "cd %s;git pull --no-edit" % repo_path
         helper.runcmd(cmd,


### PR DESCRIPTION
Incase of test repositories configured to
bootstrap from specific tags/branch, subsequent
invocation of bootstrap will result in failure
due to the fact tagged version will not have remote
branch to track, so git pull will fail, to avoid that
let's handle it by removing the folder if user
tried to bootstrap again, and start fresh, so that
new tag/branch update in config also handled.

This will help for users with env.conf like below one.
Eg:-
```
$head -4 config/wrapper/env.conf
[repo]
avocado = -b 69.0 https://github.com/avocado-framework/avocado.git
avocado_vt = -b 69.0 https://github.com/avocado-framework/avocado-vt.git
tests = -b py2-lts https://github.com/avocado-framework-tests/avocado-misc-tests.git
```
Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>