### PR TITLE
Enhancing pci library for adapter type options

### DIFF
--- a/lib/pci.py
+++ b/lib/pci.py
@@ -482,7 +482,7 @@ def get_secondary_ioa(primary_ioa):
     return ''
 
 
-def pci_info(pci_addrs, type='', pci_blacklist='', type_blacklist=''):
+def pci_info(pci_addrs, pci_type='', pci_blacklist='', type_blacklist=''):
     """
     Get all the information for given PCI addresses (comma separated).
 
@@ -502,13 +502,12 @@ def pci_info(pci_addrs, type='', pci_blacklist='', type_blacklist=''):
         pci_addrs = list(set(pci_addrs) - set(pci_blacklist))
     pci_addrs.sort()
     pci_list = []
-    if type:
-        type = list(set(type.split(',')))
+    if pci_type:
+        pci_type = list(set(pci_type.split(',')))
     else:
-        type = []
+        pci_type = []
     if type_blacklist:
         type_blacklist = type_blacklist.split(',')
-        type = list(set(type) - set(type_blacklist))
 
     for pci_addr in pci_addrs:
         pci_dic = {}
@@ -518,10 +517,12 @@ def pci_info(pci_addrs, type='', pci_blacklist='', type_blacklist=''):
         pci_dic['adapter_description'] = get_pci_name(pci_dic['functions'][0])
         pci_dic['adapter_id'] = get_pci_id(pci_dic['functions'][0])
         pci_dic['adapter_type'] = get_pci_type(pci_dic['functions'][0])
-        if pci_dic['adapter_type'] not in type:
-            continue
         pci_dic['driver'] = get_driver(pci_dic['functions'][0])
         pci_dic['slot'] = get_slot_from_sysfs(pci_dic['functions'][0])
+        if pci_dic['adapter_type'] in type_blacklist:
+            continue
+        elif "All" not in pci_type and pci_dic['adapter_type'] not in pci_type:
+            continue
         pci_dic['interfaces'] = []
         pci_dic['class'] = get_pci_class_name(pci_dic['functions'][0])
         for fun in pci_dic['functions']:
@@ -554,10 +555,10 @@ def pci_info(pci_addrs, type='', pci_blacklist='', type_blacklist=''):
     return pci_list
 
 
-def all_pci_info(type='', pci_blacklist='', type_blacklist=''):
+def all_pci_info(pci_type='', pci_blacklist='', type_blacklist=''):
     """
     Get all the information for all PCI addresses in the system.
     :return: list of dictionaries of PCI information
     """
     pci_addrs = get_pci_addresses()
-    return pci_info(",".join(pci_addrs), type=type, pci_blacklist=pci_blacklist, type_blacklist=type_blacklist)
+    return pci_info(",".join(pci_addrs), pci_type=pci_type, pci_blacklist=pci_blacklist, type_blacklist=type_blacklist)

--- a/pci_info.py
+++ b/pci_info.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 
 from pprint import pprint
-from .lib import pci
+from lib import pci
 import argparse
 import shutil
 import os
 import sys
 import configparser
-from .lib.logger import logger_init
+from lib.logger import logger_init
 
 BASE_PATH = os.path.dirname(os.path.abspath(__file__))
 CONFIG_PATH = "%s/config/wrapper/pci_input.conf" % BASE_PATH
@@ -105,8 +105,8 @@ if __name__ == '__main__':
     parser.add_argument('--pci-address-blacklist', dest='pci_addr_blacklist',
                         action='store', default='',
                         help='pci address which need not be considered, comma separated')
-    parser.add_argument('--type', dest='type',
-                        action='store', default='',
+    parser.add_argument('--type', dest='pci_type',
+                        action='store', default='All',
                         help='type of adapters, comma separated')
     parser.add_argument('--type-blacklist', dest='type_blacklist',
                         action='store', default='',
@@ -125,9 +125,9 @@ if __name__ == '__main__':
                         help='Additional parameters(key=value) to the input file, space separated')
     args = parser.parse_args()
     if args.pci_addr:
-        pci_details = pci.pci_info(args.pci_addr, type=args.type, pci_blacklist=args.pci_addr_blacklist, type_blacklist=args.type_blacklist)
+        pci_details = pci.pci_info(args.pci_addr, pci_type=args.pci_type, pci_blacklist=args.pci_addr_blacklist, type_blacklist=args.type_blacklist)
     else:
-        pci_details = pci.all_pci_info(type=args.type, pci_blacklist=args.pci_addr_blacklist, type_blacklist=args.type_blacklist)
+        pci_details = pci.all_pci_info(pci_type=args.pci_type, pci_blacklist=args.pci_addr_blacklist, type_blacklist=args.type_blacklist)
     if not pci_details:
         logger.info("No PCI Found")
         sys.exit(0)


### PR DESCRIPTION
Enhanced pci library for adapter type and adapter type blacklisting.
Fixed some variable names which were same as python keywords.
Also, fixing importing methods

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>