### PR TITLE
migration: kvm migration testcases for regression

### DIFF
--- a/config/tests/guest/libvirt/migrate.cfg
+++ b/config/tests/guest/libvirt/migrate.cfg
@@ -1,0 +1,84 @@
+include tests-shared.cfg
+
+disk_target = sda
+setup_local_nfs = yes
+username = root
+password = 123456
+main_vm = virt-tests-vm1
+vms = virt-tests-vm1
+migrate_main_vm = "${main_vm}"
+
+# Network
+nettype = bridge
+netdst=virbr0
+
+# Using Text mode of installation
+display = 'nographic'
+take_regular_screendumps = no
+keep_screendumps_on_error = no
+keep_screendumps = no
+store_vm_register = no
+virt_install_binary = /usr/bin/virt-install
+qemu_img_binary = /usr/bin/qemu-img
+hvm_or_pv = hvm
+machine_type = pseries
+only bridge
+no xen, lxc, esx, ovmf
+
+#Filterout unwanted disk types
+no ide,xenblk,lsi_scsi,ahci,sd
+no qed,qcow2v3,raw_dd,vmdk, usb2
+no e1000-82540em,e1000-82545em,e1000-82544gc,xennet,nic_custom
+only no_virtio_rng
+only smp2
+no spapr-vlan
+only no_9p_export
+only no_pci_assignable
+only (image_backend=filesystem)
+only smallpages
+smp = 32
+vcpu_cores = 32
+vcpu_threads = 1
+vcpu_sockets = 1
+
+# 8G
+mem = 8192
+
+# NFS related configurations
+storage_type = nfs
+nfs_mount_dir=/home/migrate/sharing
+nfs_mount_options="rw"
+export_options=rw,sync,no_root_squash
+nfs_mount_src=/home/migrate/NFS
+export_dir=/home/migrate/NFS
+
+# libvirt (host information for remote testcases)
+local_ip = "10.1.1.3"
+local_pwd = "password"
+remote_ip = "10.1.1.2"
+remote_user = root
+
+# Default password is same as local_pwd
+remote_pwd = "password"
+
+# Migration source and destination machine details
+migrate_source_host = "${local_ip}"
+migrate_source_pwd = "${local_pwd}"
+migrate_dest_host = "${remote_ip}"
+migrate_dest_pwd = "${remote_pwd}"
+
+# This param required for testcases with hugepages
+hugepage_force_allocate = "yes"
+
+# These params required for CPU hotplug/unplug testcases
+cpu_topology_sockets = "4"
+cpu_topology_cores = "16"
+cpu_topology_threads = "1"
+
+variants:
+    - guest_import:
+        only unattended_install.import.import.default_install.aio_native
+    - guest_migration:
+        only virsh.migrate
+    - guest_remove:
+        only remove_guest.without_disk

--- a/config/tests/guest/libvirt/migrate_stress.cfg
+++ b/config/tests/guest/libvirt/migrate_stress.cfg
@@ -1,0 +1,89 @@
+include tests-shared.cfg
+
+disk_target = sda
+setup_local_nfs = yes
+username = root
+password = 123456
+main_vm = "virt-tests-vm1"
+vms = "virt-tests-vm1 virt-tests-vm2 virt-tests-vm3 virt-tests-vm4 virt-tests-vm5 virt-tests-vm6 virt-tests-vm7 virt-tests-vm8 virt-tests-vm9 virt-tests-vm10"
+
+# Network
+nettype = bridge
+netdst=virbr0
+
+# Using Text mode of installation
+display = 'nographic'
+take_regular_screendumps = no
+keep_screendumps_on_error = no
+keep_screendumps = no
+store_vm_register = no
+virt_install_binary = /usr/bin/virt-install
+qemu_img_binary = /usr/bin/qemu-img
+hvm_or_pv = hvm
+machine_type = pseries
+only bridge
+no xen, lxc, esx, ovmf
+
+# Filterout unwanted disk types
+no ide,xenblk,lsi_scsi,ahci,sd
+no qed,qcow2v3,raw_dd,vmdk, usb2
+no e1000-82540em,e1000-82545em,e1000-82544gc,xennet,nic_custom
+only no_virtio_rng
+only smp2
+no spapr-vlan
+only no_9p_export
+only no_pci_assignable
+only (image_backend=filesystem)
+only smallpages
+smp = 32
+vcpu_cores = 2
+vcpu_threads = 8
+vcpu_sockets = 2
+
+# 8G
+mem = 8192
+
+# NFS related configurations
+storage_type = nfs
+nfs_mount_dir=/home/migrate/sharing
+nfs_mount_options="rw"
+export_options=rw,sync,no_root_squash
+nfs_mount_src=/home/migrate/NFS
+export_dir=/home/migrate/NFS
+
+# libvirt (host information for remote testcases)
+local_ip = "10.1.1.3"
+local_pwd = "password"
+remote_ip = "10.1.1.2"
+remote_user = root
+
+# Default password is same as local_pwd
+remote_pwd = "password"
+
+# Migration source and destination machine details
+migrate_source_host = "${local_ip}"
+migrate_source_pwd = "${local_pwd}"
+migrate_dest_host = "${remote_ip}"
+migrate_dest_pwd = "${remote_pwd}"
+
+# This param required for testcases with hugepages
+hugepage_force_allocate = "yes"
+
+# These params required for CPU hotplug/unplug testcases
+cpu_topology_sockets = "4"
+cpu_topology_cores = "16"
+cpu_topology_threads = "1"
+
+# set the guest image name to be cloned
+master_images_clone = "jeos-27-ppc64le"
+disk_target = sda
+setup_local_nfs = yes
+storage_type = nfs
+create_vm_libvirt = "yes"
+kill_vm_libvirt = "yes"
+kill_vm = "yes"
+
+
+variants:
+    - virsh_migrate_stress:
+        only virsh.migrate_stress

--- a/config/tests/guest/libvirt/migration.cfg
+++ b/config/tests/guest/libvirt/migration.cfg
@@ -1,0 +1,79 @@
+include tests-shared.cfg
+
+disk_target = sda
+setup_local_nfs = yes
+username = root
+password = 123456
+main_vm = virt-tests-vm1
+vms = virt-tests-vm1
+migrate_main_vm = "${main_vm}"
+
+# Network
+nettype = bridge
+netdst=virbr0
+
+# Using Text mode of installation
+display = 'nographic'
+take_regular_screendumps = no
+keep_screendumps_on_error = no
+keep_screendumps = no
+store_vm_register = no
+virt_install_binary = /usr/bin/virt-install
+qemu_img_binary = /usr/bin/qemu-img
+hvm_or_pv = hvm
+machine_type = pseries
+only bridge
+no xen, lxc, esx, ovmf
+
+# Filterout unwanted disk types
+no ide,xenblk,lsi_scsi,ahci,sd
+no qed,qcow2v3,raw_dd,vmdk, usb2
+no e1000-82540em,e1000-82545em,e1000-82544gc,xennet,nic_custom
+only no_virtio_rng
+only smp2
+no spapr-vlan
+only no_9p_export
+only no_pci_assignable
+only (image_backend=filesystem)
+only smallpages
+smp = 32
+vcpu_cores = 32
+vcpu_threads = 1
+vcpu_sockets = 1
+
+# 8G
+mem = 8192
+
+# NFS related configurations
+storage_type = nfs
+nfs_mount_dir=/home/migrate/sharing
+nfs_mount_options="rw"
+export_options=rw,sync,no_root_squash
+nfs_mount_src=/home/migrate/NFS
+export_dir=/home/migrate/NFS
+
+# libvirt (host information for remote testcases)
+local_ip = "10.1.1.3"
+local_pwd = "password"
+remote_ip = "10.1.1.2"
+remote_user = root
+
+# Default password is same as local_pwd
+remote_pwd = "password"
+
+# Migration source and destination machine details
+migrate_source_host = "${local_ip}"
+migrate_source_pwd = "${local_pwd}"
+migrate_dest_host = "${remote_ip}"
+migrate_dest_pwd = "${remote_pwd}"
+
+hugepage_force_allocate = "yes"
+ping_count = 10
+
+variants:
+    - guest_import:
+        only unattended_install.import.import.default_install.aio_native
+    - guest_migration:
+        only virsh.migration
+    - guest_remove:
+        only remove_guest.without_disk


### PR DESCRIPTION
add kvm migration testcases using libvirt as config for regression
suite

Signed-off-by: Balamuruhan S <bala24@linux.ibm.com>