### PR TITLE
Adding a way to specify generic norun tests

### DIFF
--- a/README
+++ b/README
@@ -301,7 +301,7 @@
     Some tests have the potential of causing system crashes / hangs. Such test in cfg file hinders the run of tests that follow.
     So, if such tests are identified and need to be "not run" for a particular environment (Since they can run fine on others),
     we have a provision to mention such tests to not run.
-    Please have a look at "config/wrapper/no_run_test.conf"
+    Please have a look at "config/wrapper/no_run_tests.conf"
 
 
 7. REFERENCE LINKS

--- a/avocado-setup.py
+++ b/avocado-setup.py
@@ -449,16 +449,28 @@ def parse_test_config(test_config_file, avocado_bin, enable_kvm):
         for section in [dist, major, minor, minor_env]:
             if NORUNTESTFILE.has_section(section):
                 norun_tests.extend(NORUNTESTFILE.get(section, 'tests').split(','))
+        norun_tests = list(filter(None, norun_tests))
 
         with open(test_config_file, 'r') as fp:
             test_config_contents = fp.read()
         test_list = []
         mux_flag = 0
         for line in test_config_contents.splitlines():
+            norun_flag = False
             test_dic = {}
-            if line in norun_tests:
-                continue
+            # Comment line or Empty line filtering
             if line.startswith("#") or not line:
+                norun_flag = True
+            # Filtering <test yaml> combination
+            elif line in norun_tests:
+                norun_flag = True
+            # Filtering <string*> pattern
+            else:
+                for norun_test in norun_tests:
+                    if norun_test.endswith('*') and line.startswith(norun_test[:-1]):
+                        norun_flag = True
+                        break
+            if norun_flag:
                 continue
             line = line.split()
             test_dic['test'] = line[0].strip('$')

--- a/avocado-setup.py
+++ b/avocado-setup.py
@@ -442,11 +442,12 @@ def parse_test_config(test_config_file, avocado_bin, enable_kvm):
         (env_ver, env_type, cmdpat) = helper.get_env_type(enable_kvm)
         norun_tests = []
         # Get common set of not needed tests
+        env = 'norun_%s' % env_type
         dist = 'norun_%s' % helper.get_dist()[0]
         major = 'norun_%s' % env_ver.split('.')[0]
         minor = 'norun_%s' % env_ver
         minor_env = 'norun_%s_%s' % (env_ver, env_type)
-        for section in [dist, major, minor, minor_env]:
+        for section in [env, dist, major, minor, minor_env]:
             if NORUNTESTFILE.has_section(section):
                 norun_tests.extend(NORUNTESTFILE.get(section, 'tests').split(','))
         norun_tests = list(filter(None, norun_tests))

--- a/config/wrapper/no_run_tests.conf
+++ b/config/wrapper/no_run_tests.conf
@@ -9,6 +9,10 @@
 # Each test-yaml pair is treated as a different test, and test without yaml is treated as a different test, as should be.
 
 
+[norun_NV]
+tests =
+[norun_pHyp]
+tests =
 [norun_centos]
 tests =
 [norun_centos_NV]

--- a/config/wrapper/no_run_tests.conf
+++ b/config/wrapper/no_run_tests.conf
@@ -4,6 +4,8 @@
 # You do not want to run "avocado-misc-tests/io/disk/ioping.py avocado-misc-tests/io/disk/ioping.py.data/ioping.yaml"
 # example.cfg contains this test, so it will not run this test.
 # But if there is another cfg which has "avocado-misc-tests/io/disk/ioping.py" test, that will run.
+# If you do not want to run "avocado-misc-tests/io/disk/ioping.py" test, irrespective of yamls, add a * to the end in
+# this file. That makes any test starting with "avocado-misc-tests/io/disk/ioping.py" to not run
 # Each test-yaml pair is treated as a different test, and test without yaml is treated as a different test, as should be.
 
 


### PR DESCRIPTION
Sometimes, we do not want a test to run, irrespective of its
variants (with yaml, subtest, etc). So we provide a way to
achieve that.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>