### PR TITLE
Fix: flag set for package install check

### DIFF
--- a/lib/helper.py
+++ b/lib/helper.py
@@ -152,5 +152,5 @@ def install_packages(package_list):
         if status != 0:
             logger.error("%s not installed" % pkg)
             logger.debug(output)
-        not_installed = True
+            not_installed = True
     return not_installed


### PR DESCRIPTION
Patch fixes the flag set when packages are not actually installed

Signed-off-by: Harish <harish@linux.ibm.com>