### PR TITLE
Isolate virsh.domtime.positive.managedsave_vm test to change memory

### DIFF
--- a/config/tests/guest/libvirt/cpu.cfg
+++ b/config/tests/guest/libvirt/cpu.cfg
@@ -3,10 +3,8 @@ username = root
 password = 123456
 main_vm = virt-tests-vm1
 vms = virt-tests-vm1
-#Network
 nettype = bridge
 netdst=virbr0
-# Using Text mode of installation
 display = 'nographic'
 take_regular_screendumps = no
 keep_screendumps_on_error = no
@@ -18,7 +16,7 @@ hvm_or_pv = hvm
 machine_type = pseries
 only bridge
 no xen, lxc, esx, ovmf
-#Filterout unwanted disk types
+# Filterout unwanted disk types
 no ide,xenblk,lsi_scsi,ahci,sd
 no qed,qcow2v3,raw_dd,vmdk, usb2
 no e1000-82540em,e1000-82545em,e1000-82544gc,xennet,nic_custom
@@ -32,8 +30,7 @@ smp = 32
 vcpu_cores = 32
 vcpu_threads = 1
 vcpu_sockets = 1
-# 32G
-mem = 32768
+mem = 32768  # 32G
 setvcpus_max = 32
 
 variants:
@@ -52,7 +49,7 @@ variants:
                 only virsh.vcpuinfo
             - vcpupin:
                 only virsh.vcpupin,guestpin
-                no virsh.vcpupin.online.positive_test.initial_check # Bug https://bugzilla.linux.ibm.com/show_bug.cgi?id=147326 - Will not fix
+                no virsh.vcpupin.online.positive_test.initial_check  # Bug https://bugzilla.linux.ibm.com/show_bug.cgi?id=147326 - Will not fix
             - maxvcpus:
                 only virsh.maxvcpus
             - nodecpumap:
@@ -63,7 +60,7 @@ variants:
                 only virsh.cpu_compare
             - numatune:
                 only virsh.numatune
-                no virsh.numatune..running_guest.cgroup.stop # Bug https://bugzilla.linux.ibm.com/show_bug.cgi?id=147329 - Will not fix
+                no virsh.numatune..running_guest.cgroup.stop  # Bug https://bugzilla.linux.ibm.com/show_bug.cgi?id=147329 - Will not fix
             - vcpucount:
                 only virsh.vcpucount
             - setvcpus:
@@ -85,6 +82,7 @@ variants:
                 no libvirt_bench.vcpu_hotplug.io_stress
             - timermanagement:
                 only clock_getres,virsh.domtime
+                no virsh.domtime.positive.managedsave_vm
             - setvcpu:
                 only virsh.setvcpu
             - guestsmt:
@@ -102,6 +100,15 @@ variants:
 
     - guest_remove:
         only remove_guest.without_disk
+
+    - cpu_domtime_managedsave:
+        smp = 4
+        vcpu_cores = 4
+        vcpu_threads = 1
+        vcpu_sockets = 1
+        mem = 1024  # 1G
+        setvcpus_max = 4
+        only unattended_install.import.import.default_install.aio_native,virsh.domtime.positive.managedsave_vm,remove_guest.without_disk
 
     - guest:
         variants:


### PR DESCRIPTION
Move virsh.domtime.positive.managedsave_vm test run separately, to
change the guest memory inorder to avoid false failure, looks
like the guest VM takes slightly longer time to managedsave
with more memory, which leads to wrong calculation for VM
stoptime to assert a virsh.domtime.positive.managedsave_vm
test, so isolate the test and re-define with lesser guest memory.

Earlier, guest with mem=32G
virsh.domtime.positive.managedsave_vm -> TestFail: For local_sys,
expect get time 2009-02-15 05:01:33.633078, got 2009-02-15 05:01:37.537122, time diff: 3.904044

with guest mem=1G
(1/3) ..qemu.unattended_install.import.import.default_install.aio_native: PASS (73.05 s)
(2/3) ..-libvirt.virsh.domtime.positive.managedsave_vm: PASS (145.40 s)
(3/3) ..-libvirt.remove_guest.without_disk: PASS (8.90 s)

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>