### PR TITLE
Add test config for upstream qemu and guest kernel

### DIFF
--- a/config/tests/guest/libvirt/upstream.cfg
+++ b/config/tests/guest/libvirt/upstream.cfg
@@ -1,0 +1,250 @@
+include tests-shared.cfg
+username = root
+password = 123456
+main_vm = vm1
+vms = vm1
+nettype = bridge
+netdst=virbr0
+display = nographic
+take_regular_screendumps = no
+keep_screendumps_on_error = no
+keep_screendumps = no
+store_vm_register = no
+restore_image_after_testing=no
+vga=none
+virt_install_binary = /usr/bin/virt-install
+hvm_or_pv = hvm
+machine_type = pseries
+only bridge
+no xen, lxc, esx, ovmf
+#Filterout unwanted disk types
+no qed,qcow2v3,raw_dd,vmdk, usb2
+only no_virtio_rng
+only smp2
+only no_9p_export
+only no_pci_assignable
+only (image_backend=filesystem)
+create_vm_libvirt=yes
+kill_vm=yes
+kill_vm_libvirt=yes
+env_cleanup=yes
+mem=8192
+smp=8
+threads=1
+cores=8
+sockets=1
+vcpu_sockets=1
+vcpu_cores=8
+vcpu_threads=1
+setvcpus_max = 8
+vcpu_maxcpus = 8
+qemu_binary=/usr/share/avocado-plugins-vt/bin/qemu
+emulator_path=/usr/share/avocado-plugins-vt/bin/qemu
+kernel=/home/kvmci/linux/vmlinux
+initrd=''
+use_serial_login=yes
+variants:
+    - upstreamtest:
+        only file_transfer.default_setting
+        variants:
+            - @:
+            - with_numa:
+                only with_smt1
+                numa=yes
+                smp=8
+                threads=1
+                cores=8
+                sockets=1
+                setvcpus_max = 8
+                vcpu_maxcpus = 8
+                vcpu_cores = 8
+                vcpu_threads = 1
+                guest_numa_nodes="node0 node1 node2 node3"
+                variants:
+                    - symmetric_nodes:
+                        numa_mem_node0="2097152"
+                        numa_cpus_node0="0-1"
+                        numa_nodeid_node0="0"
+                        numa_mem_node1="2097152"
+                        numa_cpus_node1="2-3"
+                        numa_nodeid_node1="1"
+                        numa_mem_node2="2097152"
+                        numa_cpus_node2="4-5"
+                        numa_nodeid_node2="2"
+                        numa_mem_node3="2097152"
+                        numa_cpus_node3="6-7"
+                        numa_nodeid_node3="3"
+                    - with_memless_node:
+                        numa_mem_node0="2097152"
+                        numa_cpus_node0="0-1"
+                        numa_nodeid_node0="0"
+                        numa_mem_node1="0"
+                        numa_cpus_node1="2-3"
+                        numa_nodeid_node1="1"
+                        numa_mem_node2="4194304"
+                        numa_cpus_node2="4-5"
+                        numa_nodeid_node2="2"
+                        numa_mem_node3="2097152"
+                        numa_cpus_node3="6-7"
+                        numa_nodeid_node3="3"
+                    - asymmetric_nodes:
+                        numa_mem_node0="0"
+                        numa_cpus_node0="1,3,7"
+                        numa_nodeid_node0="0"
+                        numa_mem_node1="0"
+                        numa_cpus_node1="0,4-5"
+                        numa_nodeid_node1="1"
+                        numa_mem_node2="0"
+                        numa_cpus_node2="2"
+                        numa_nodeid_node2="2"
+                        numa_mem_node3="8388608"
+                        numa_cpus_node3="6"
+                        numa_nodeid_node3="3"
+        variants:
+            - @:
+            - with_smt1:
+                smp=8
+                threads=1
+                cores=8
+                sockets=1
+                setvcpus_max=8
+                vcpu_maxcpus=8
+                vcpu_cores=8
+                vcpu_threads=1
+                vcpu_sockets=1
+            - with_smt2:
+                smp=8
+                threads=2
+                cores=4
+                sockets=1
+                setvcpus_max=8
+                vcpu_maxcpus=8
+                vcpu_cores=4
+                vcpu_threads=2
+                vcpu_sockets=1
+            - with_smt4:
+                smp=8
+                threads=4
+                cores=2
+                sockets=1
+                setvcpus_max=8
+                vcpu_maxcpus=8
+                vcpu_cores=2
+                vcpu_threads=4
+                vcpu_sockets=1
+            - with_smt8:
+                smp=8
+                threads=4
+                cores=2
+                sockets=1
+                setvcpus_max=8
+                vcpu_maxcpus=8
+                vcpu_cores=2
+                vcpu_threads=4
+                vcpu_sockets=1
+            - with_lowmem:
+                no with_numa
+                mem=512
+            - with_singlecpu:
+                only with_smt1
+                smp=1
+                threads=1
+                cores=1
+                sockets=1
+                setvcpus_max=1
+                vcpu_maxcpus=1
+                vcpu_cores=1
+                vcpu_threads=1
+                vcpu_sockets=1
+        variants:
+            - @:
+            - with_intc:
+                only with_smt4
+                variants:
+                    - xics:
+                        virtinstall_qemu_cmdline_vm1=" -M pseries,ic-mode=xics"
+                    - xive:
+                        virtinstall_qemu_cmdline_vm1=" -M pseries,ic-mode=xive"
+                    - dual:
+                        virtinstall_qemu_cmdline_vm1=" -M pseries,ic-mode=dual"
+                    - xics_kernel_irqchip_off:
+                        virtinstall_qemu_cmdline_vm1=" -M pseries,ic-mode=xics,kernel-irqchip=off"
+                    - xive_kernel_irqchip_off:
+                        virtinstall_qemu_cmdline_vm1=" -M pseries,ic-mode=xive,kernel-irqchip=off"
+                    - dual_kernel_irqchip_off:
+                        virtinstall_qemu_cmdline_vm1=" -M pseries,ic-mode=dual,kernel-irqchip=off"
+                    - multiple:
+                        vms = "vm1 vm2 vm3 vm4 vm5 vm6 vm7 vm8"
+                        master_images_clone = img1
+                        virtinstall_qemu_cmdline_vm1=" -M pseries,ic-mode=dual"
+                        virtinstall_qemu_cmdline_vm2=" -M pseries,ic-mode=xive"
+                        virtinstall_qemu_cmdline_vm3=" -M pseries,ic-mode=xics"
+                        virtinstall_qemu_cmdline_vm4=" -M pseries,ic-mode=dual,max-cpu-compat=power8"
+                        virtinstall_qemu_cmdline_vm5=" -M pseries,ic-mode=dual,kernel-irqchip=off"
+                        virtinstall_qemu_cmdline_vm6=" -M pseries,ic-mode=xive,kernel-irqchip=off"
+                        virtinstall_qemu_cmdline_vm7=" -M pseries,ic-mode=xics,kernel-irqchip=off"
+                        virtinstall_qemu_cmdline_vm8=" -M pseries,ic-mode=dual,max-cpu-compat=power8,kernel-irqchip=off"
+            - with_vsmt:
+                no with_intc,mem_merge,with_numa
+                only with_smt1
+                vms = "vm1 vm2 vm3 vm4"
+                master_images_clone = img1
+                cores_vm2=4
+                threads_vm2=2
+                sockets_vm2=1
+                vcpu_cores_vm2=4
+                vcpu_threads_vm2=2
+                vcpu_sockets=1
+                cores_vm3=2
+                threads_vm3=4
+                sockets_vm3=1
+                vcpu_cores_vm3=2
+                vcpu_threads_vm3=4
+                vcpu_sockets_vm3=1
+                cores_vm4=1
+                threads_vm4=8
+                sockets=1
+                vcpu_cores_vm4=1
+                vcpu_threads_vm4=8
+                vcpu_sockets_vm4=1
+                virtinstall_qemu_cmdline_vm1=" -M pseries,vsmt=1"
+                virtinstall_qemu_cmdline_vm2=" -M pseries,vsmt=2"
+                virtinstall_qemu_cmdline_vm3=" -M pseries,vsmt=4"
+                virtinstall_qemu_cmdline_vm4=" -M pseries,vsmt=8"
+            - mem_merge:
+                no with_intc,with_vsmt
+                only with_smt2
+                variants:
+                    - enable:
+                        virtinstall_qemu_cmdline_vm1=" -M pseries,ic-mode=dual,mem-merge=True"
+                        virtinstall_qemu_cmdline_vm2=" -M pseries,ic-mode=xive,mem-merge=True"
+                        virtinstall_qemu_cmdline_vm3=" -M pseries,ic-mode=xics,mem-merge=True"
+                        virtinstall_qemu_cmdline_vm4=" -M pseries,ic-mode=dual,max-cpu-compat=power8,mem-merge=True"
+                        virtinstall_qemu_cmdline_vm5=" -M pseries,ic-mode=dual,kernel-irqchip=off,mem-merge=True"
+                        virtinstall_qemu_cmdline_vm6=" -M pseries,ic-mode=xive,kernel-irqchip=off,mem-merge=True"
+                        virtinstall_qemu_cmdline_vm7=" -M pseries,ic-mode=xics,kernel-irqchip=off,mem-merge=True"
+                        virtinstall_qemu_cmdline_vm8=" -M pseries,ic-mode=dual,max-cpu-compat=power8,kernel-irqchip=off,mem-merge=True"
+                   - disable:
+                        virtinstall_qemu_cmdline_vm1=" -M pseries,ic-mode=dual,mem-merge=False"
+                        virtinstall_qemu_cmdline_vm2=" -M pseries,ic-mode=xive,mem-merge=False"
+                        virtinstall_qemu_cmdline_vm3=" -M pseries,ic-mode=xics,mem-merge=False"
+                        virtinstall_qemu_cmdline_vm4=" -M pseries,ic-mode=dual,max-cpu-compat=power8,mem-merge=False"
+                        virtinstall_qemu_cmdline_vm5=" -M pseries,ic-mode=dual,kernel-irqchip=off,mem-merge=False"
+                        virtinstall_qemu_cmdline_vm6=" -M pseries,ic-mode=xive,kernel-irqchip=off,mem-merge=False"
+                        virtinstall_qemu_cmdline_vm7=" -M pseries,ic-mode=xics,kernel-irqchip=off,mem-merge=False"
+                        virtinstall_qemu_cmdline_vm8=" -M pseries,ic-mode=dual,max-cpu-compat=power8,kernel-irqchip=off,mem-merge=False"
+            #- with_nested_cap:
+            #    no with_vsmt,with_intc,mem_merge
+            #    only with_smt4
+            #    virtinstall_qemu_cmdline_vm1=" -M pseries,cap-nested-hv=True"
+        variants:
+            - with_virtio_scsi:
+                kernel_args='root=/dev/sda2 rw console=tty0 console=ttyS0,115200 init=/sbin/init initcall_debug selinux=0'
+                no with_virtio_blk
+                only virtio_scsi
+            - with_virtio_blk:
+                kernel_args='root=/dev/vda2 rw console=tty0 console=ttyS0,115200 init=/sbin/init initcall_debug selinux=0'
+                no with_virtio_scsi
+                only virtio_blk
+only virtio_net
+only qcow2


### PR DESCRIPTION
Add initial test config to test upstream qemu and guest
kernel, it adds tests with permutations and combinations of
different pseries machines options.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>