### PR TITLE
Fix issue in  avocado-setup

### DIFF
--- a/avocado-setup.py
+++ b/avocado-setup.py
@@ -219,7 +219,8 @@ def install_repo(path, name):
     :param repo: repository path
     :param name: name of the repository
     """
-    cmd = "cd %s;make requirements;make requirements-selftests;python setup.py install" % path
+    cmd = "cd %s;make requirements;make requirements-selftests;python%s setup.py install" % (path,
+                                                                                             sys.version_info.major)
     helper.runcmd(cmd, info_str="Installing %s from %s" % (name, path),
                   err_str="Failed to install %s repository:" % name)
 


### PR DESCRIPTION
as python binary  is hardcoded for library setup
as if system does not have python and it just have python3
or python2 user need to create softlink to proceed that should not
be the case , this commit get python version in run time and resolve
cmdline

without this fix :

 python3 avocado-setup.py
15:01:24 INFO    : Check for environment
15:01:24 INFO    : Creating temporary mux dir
15:01:24 INFO    : Creating Avocado Config
15:01:24 INFO    : Bootstrapping Avocado
15:01:24 INFO    : Cloning the repo: avocado in /root/tests/avocado
15:01:27 INFO    : Installing avocado from /root/tests/avocado
15:02:19 ERROR   : Failed to install avocado repository: make: *** No rule to make target 'requirements'.  Stop.
/usr/bin/python3 -m pip --version || /usr/bin/python3 -m ensurepip --user || /usr/bin/python3 -c "import os; import sys; import urllib; f = urllib.urlretrieve('https://bootstrap.pypa.io/get-pip.py')[0]; os.system('%s %s' % (sys.executable, f))"
pip 9.0.3 from /usr/lib/python3.6/site-packages (python 3.6)
/usr/bin/python3 -m pip install -r requirements-selftests.txt
WARNING: Running pip install with root privileges is generally not a good idea. Try `__main__.py install --user` instead.
Collecting pylint==2.3.0 (from -r requirements-selftests.txt (line 4))
  Downloading https://files.pythonhosted.org/packages/53/cc/c85a8ed4d2f5e69dff4d9c2a1d69cc3f069e1321a2e2dc67f57e02fa2179/pylint-2.3.0-py3-none-any.whl (764kB)

with fix:

[root@ tests]# python3 avocado-setup.py
15:24:33 INFO    : Check for environment
15:24:33 INFO    : Creating Avocado Config
15:24:33 INFO    : Bootstrapping Avocado
15:24:33 INFO    : Cloning the repo: avocado in /root/tests/avocado
15:24:36 INFO    : Installing avocado from /root/tests/avocado
15:24:47 INFO    : Cloning the repo: avocado-misc-tests in /root/tests/tests/avocado-misc-tests
15:24:50 WARNING : Avocado html plugin not installed
15:24:50 INFO    : Installing optional plugin: html
15:24:50 WARNING : Avocado varianter_yaml_to_mux plugin not installed
15:24:50 INFO    : Installing optional plugin: varianter_yaml_to_mux
15:24:50 INFO    : Removing temporary mux dir
[root@ tests]# avocado -v
Avocado 73.0

Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>