### PR TITLE
Fixup: remove unwanted comment from mem param value

### DIFF
--- a/config/tests/guest/libvirt/cpu.cfg
+++ b/config/tests/guest/libvirt/cpu.cfg
@@ -30,7 +30,8 @@ smp = 32
 vcpu_cores = 32
 vcpu_threads = 1
 vcpu_sockets = 1
-mem = 32768  # 32G
+# 32G
+mem = 32768
 setvcpus_max = 32
 
 variants:
@@ -106,7 +107,8 @@ variants:
         vcpu_cores = 4
         vcpu_threads = 1
         vcpu_sockets = 1
-        mem = 1024  # 1G
+        # 1G
+        mem = 1024
         setvcpus_max = 4
         only unattended_install.import.import.default_install.aio_native,virsh.domtime.positive.managedsave_vm,remove_guest.without_disk
 


### PR DESCRIPTION
Remove the unwanted comment from mem param value
which resulted in a comment used for guest creation.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>