### PR TITLE
Add option to provide test-specific args through host config

### DIFF
--- a/README
+++ b/README
@@ -295,8 +295,9 @@
          - The user runs the host_sanity suite using the avocado-setup.py script explained in Section 4 above.
          - If the user wishes to run a test with yaml file inputs, the yaml file can be specified in the same line in the cfg file,
          separated by a space. Refer config/tests/host/example.cfg for example.
-         - If the user wishes to run a test with yaml by specifying execution order, the order {tests-per-variant,variants-per-test}
-         can be specified in the same line, after yaml, separated by a space.
+         - If the user wishes to run a test with test-specific additional arguements such as --execution-order, --mux-filer-only etc.,
+         those can be specified in the same line. Note that test-specific arguements can be provided with or without the yaml,
+         followed by a space within quotes. Refer config/tests/host/example.cfg for example
 
 
 6. NO RUN TEST

--- a/config/tests/host/example.cfg
+++ b/config/tests/host/example.cfg
@@ -1,2 +1,3 @@
-avocado-misc-tests/io/disk/ioping.py avocado-misc-tests/io/disk/ioping.py.data/ioping.yaml tests-per-variant
+avocado-misc-tests/io/disk/ioping.py avocado-misc-tests/io/disk/ioping.py.data/ioping.yaml "--execution-order tests-per-variant"
 avocado-misc-tests/io/disk/fs_mark.py avocado-misc-tests/io/disk/fs_mark.py.data/fs_mark.yaml
+avocado-misc-tests/memory/ndctl.py "--mux-filter-out /run/config/mode_types"


### PR DESCRIPTION
Patch adds a way to provide test-specific arguments through config file replacing the existing execution order as the input through config file.

Signed-off-by: Harish <harish@linux.ibm.com>