### PR TITLE
Linux OS Regression config

### DIFF
--- a/config/tests/host/os_regression.cfg
+++ b/config/tests/host/os_regression.cfg
@@ -1,0 +1,31 @@
+# A collection of Linux On POWER OS Regression tests which provide results in 
+# few (< 5 hrs) hours
+avocado-misc-tests/cpu/em_cpupower.py
+avocado-misc-tests/cpu/sensors.py
+avocado-misc-tests/cpu/em_cpufreq.py
+avocado-misc-tests/cpu/em_cpuidle.py
+avocado-misc-tests/cpu/cpustress.py
+avocado-misc-tests/cpu/dwh.py
+avocado-misc-tests/cpu/ebizzy.py
+avocado-misc-tests/cpu/numactl.py
+avocado-misc-tests/fs/fsx.py avocado-misc-tests/fs/fsx.py.data/fsx.yaml
+avocado-misc-tests/generic/ltp.py
+avocado-misc-tests/kernel/kselftest.py
+avocado-misc-tests/memory/hugepage_sanity.py
+avocado-misc-tests/memory/libhugetlbfs.py
+avocado-misc-tests/memory/fork_mem.py
+avocado-misc-tests/memory/memory_api.py
+avocado-misc-tests/memory/mprotect.py
+avocado-misc-tests/memory/stutter.py
+avocado-misc-tests/memory/sum_check.py
+avocado-misc-tests/memory/eatmemory.py
+avocado-misc-tests/memory/integrity.py avocado-misc-tests/memory/integrity.py.data/integrity.yaml
+avocado-misc-tests/memory/memcached.py avocado-misc-tests/memory/memcached.py.data/memcached.yaml
+avocado-misc-tests/memory/vatest.py avocado-misc-tests/memory/vatest.py.data/vatest.yaml
+avocado-misc-tests/perf/perfmon.py
+avocado-misc-tests/perf/perf_pcp.py
+avocado-misc-tests/perf/perf_24x7_hardware_counters.py
+avocado-misc-tests/perf/perf_genericevents.py
+avocado-misc-tests/ras/ras.py
+avocado-misc-tests/ras/ras_extended.py
+avocado-misc-tests/ras/sosreport.py


### PR DESCRIPTION
This patch adds a Linux OS regression config which can provide test results in few ( < 5 hrs) hours.

Signed-off-by: Sachin Sant <sachinp@linux.vnet.ibm.com>