### PR TITLE
This patch address the issue which is introduced by patch 393e566a660f6ee8b3235466768f2f919416db98

### DIFF
--- a/avocado-setup.py
+++ b/avocado-setup.py
@@ -340,14 +340,16 @@ def bootstrap(enable_kvm=False):
     for repo in TEST_REPOS:
         get_repo(repo, TEST_DIR)
 
-    if len(os.listdir(prescript)):
-        if not os.path.exists(prescript_dir):
-            os.makedirs(prescript_dir)
-        helper.copy_dir_file(prescript, prescript_dir)
-    if len(os.listdir(postscipt)):
-        if not os.path.exists(prescript_dir):
-            os.makedirs(postscipt_dir)
-        helper.copy_dir_file(postscipt, postscipt_dir)
+    if os.path.isdir(prescript):
+        if len(os.listdir(prescript)):
+            if not os.path.exists(prescript_dir):
+                os.makedirs(prescript_dir)
+            helper.copy_dir_file(prescript, prescript_dir)
+    if os.path.isdir(postscipt):
+        if len(os.listdir(postscipt)):
+            if not os.path.exists(prescript_dir):
+                os.makedirs(postscipt_dir)
+            helper.copy_dir_file(postscipt, postscipt_dir)
 
 
 def run_test(testsuite, avocado_bin):


### PR DESCRIPTION
https://github.com/open-power-host-os/tests/commit/393e566a660f6ee8b3235466768f2f919416db98

as if prescript/postscript  directory not present in path framework error out

Reported-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>
Signed-off-by: Praveen K Pandey <praveen@linux.vnet.ibm.com>