### PR TITLE
Update guest boot config

### DIFF
--- a/config/tests/guest/libvirt/boot.cfg
+++ b/config/tests/guest/libvirt/boot.cfg
@@ -10,8 +10,8 @@ use_os_variant = yes
 use_os_type = yes
 only qcow2
 only bridge
-only scsi
-only spapr-vlan
+only virtio_scsi
+only virtio_net
 only smp2
 only no_9p_export
 only no_virtio_rng


### PR DESCRIPTION
ibmvscsi and spapr-vlan types for
disk and network respectively got outdated,
let's update with current default and widely
used ones.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>