### PR TITLE
Adding openssl-devel pacakge in rhel8 dependency

### DIFF
--- a/config/wrapper/env.conf
+++ b/config/wrapper/env.conf
@@ -44,7 +44,7 @@ packages =
 [deps_rhel7_kvm]
 packages = p7zip,libvirt-devel,tcpdump,virt-install,qemu,libvirt,SLOF,genisoimage,attr
 [deps_rhel8]
-packages = gcc,python36-devel,xz-devel,python3-setuptools,numactl,policycoreutils-python-utils
+packages = gcc,python36-devel,xz-devel,python3-setuptools,numactl,policycoreutils-python-utils,openssl-devel
 [deps_rhel8_NV]
 packages =
 [deps_rhel8_pHyp]


### PR DESCRIPTION
Adding openssl-devel pacakge in rhel8 dependency, as it is needed
for network tests. It is mainly needed for paramiko python package
installation, so adding in env is the only way to solve it.

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>