### PR TITLE
Fixup for env_cleanup of pre/post script dir

### DIFF
--- a/avocado-setup.py
+++ b/avocado-setup.py
@@ -422,10 +422,10 @@ def env_clean():
         helper.runcmd(cmd, ignore_status=True,
                       err_str="Error in removing package: %s" % package,
                       debug_str="Uninstalling %s" % package)
-    if os.path.isdir(prescript_dir):
+    if os.path.isdir(prescript):
         helper.remove_file(prescript, prescript_dir)
 
-    if os.path.isdir(postscript_dir):
+    if os.path.isdir(postscript):
         helper.remove_file(postscript, postscript_dir)
 
 

--- a/lib/helper.py
+++ b/lib/helper.py
@@ -181,4 +181,4 @@ def remove_file(src, dest):
         d_file = os.path.join(dest, item)
         if os.path.exists(d_file):
             os.remove(d_file)
-    logger.debug("%s file deleted" % d_file)
+        logger.debug("%s file deleted" % d_file)


### PR DESCRIPTION
Cleanup checks for avocado pre/post script directory, and then
goes for cleanup of the directory. But ideally we should be
checking for our pre/post script directory. So we get the below
error. Fixing this with this commit.

Traceback (most recent call last):
  File "./avocado-setup.py", line 653, in <module>
    bootstrap(args.enable_kvm)
  File "./avocado-setup.py", line 340, in bootstrap
    env_clean()
  File "./avocado-setup.py", line 426, in env_clean
    helper.remove_file(prescript, prescript_dir)
  File "/root/wrapper/tests/lib/helper.py", line 180, in remove_file
    for item in os.listdir(src):
FileNotFoundError: [Errno 2] No such file or directory:
'/root/wrapper/tests/config/prescript'

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>
Reported by: Vaishnavi Bhat <aishnavi@linux.vnet.ibm.com>