### PR TITLE
config.guest.cpu: Add ppccpucompat test

### DIFF
--- a/config/tests/guest/libvirt/cpu.cfg
+++ b/config/tests/guest/libvirt/cpu.cfg
@@ -98,6 +98,8 @@ variants:
                 only powerpc_hmi
             - numacaps:
                 only numa_capabilities
+            - cpucompattest:
+                only ppccpucompat
 
     - guest_remove:
         only remove_guest.without_disk


### PR DESCRIPTION
Add ppccpucompat test to guest cpu config.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>