### PR TITLE
Enable leaf level input for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,8 +171,17 @@ $ ./avocado-setup.py -h
     Now, it has yaml parameters like mode, count, deadline, period, disk, etc.
     Suppose user wants to change only 3 of those values, say disk, wsize and period, user can have that alone in our input file.
     User must specify config key value matching the branch of the yaml through dotted notation.
+    Optinally users can also provide input with '*' as part of config key, if the config key needs to be matched irrespective of its parent branch.
+    Please note that it is better to provide strings without quotes, since it is unnecessary though not harmful
     Refer [input_example.txt](input_example.txt) for this example.
 
+    Note: The newer yaml.[load->dump] implementation preserves all the data types on unchanged yaml files as is.
+    For inputs changed through yaml, the following data types are handled:
+    1. bool (True, true, yes are all True, and False, false, no are all False)
+    2. int is preserved if specified input is digits
+    3. list input is not preserved (treated as string "[1, 2, 3]")
+    4. everything else is treated as string.
+    So if there is any other data type, users must provide them as string in yaml and parse in test accordingly (eg: list type)
 
 5. `--verbose`:
     > Use this option to display test verbose output on the console.

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ $ ./avocado-setup.py -h
     >It contains 1 yaml file,namely [ioping.yaml](https://github.com/avocado-framework-tests/avocado-misc-tests/blob/master/io/disk/ioping.py.data/ioping.yaml)
     Now, it has yaml parameters like mode, count, deadline, period, disk, etc.
     Suppose user wants to change only 3 of those values, say disk, wsize and period, user can have that alone in our input file.
+    User must specify config key value matching the branch of the yaml through dotted notation.
     Refer [input_example.txt](input_example.txt) for this example.
 
 

--- a/avocado-setup.py
+++ b/avocado-setup.py
@@ -454,14 +454,27 @@ def edit_mux_file(test_config_name, mux_file_path, tmp_mux_path):
     mux_json = yaml.load(mux_str, yaml_helper.OverrideLoader)
 
     for key, value in input_dic.items():
-        if helper.keys_exists(mux_json, *(key.split("."))):
+        keys = key.split(".")
+        keys_list = []
+        st_keys, flag = helper.keys_exists(mux_json, *keys)
+        if flag:
+            if not st_keys:
+                keys_list.append(keys)
+            for st_key in st_keys:
+                for index, key_val in st_key.items():
+                    for val in key_val:
+                        keys[index] = val
+                        # Add only complete list without * in it
+                        if "*" not in keys:
+                            keys_list.append(keys.copy())
+        for key_update in keys_list:
             if value.lower() in ['true', 'false']:
                 helper.deep_put(
-                    key.split("."), mux_json, json.loads(value.lower()))
+                    key_update, mux_json, json.loads(value.lower()))
             elif value.isdigit():
-                helper.deep_put(key.split("."), mux_json, int(value))
+                helper.deep_put(key_update, mux_json, int(value))
             else:
-                helper.deep_put(key.split("."), mux_json, value)
+                helper.deep_put(key_update, mux_json, value)
 
     final_data = yaml.dump(
         mux_json, Dumper=yaml_helper.OverrideDumper, indent=4,

--- a/input_example.txt
+++ b/input_example.txt
@@ -1,4 +1,10 @@
 [example]
-disk = '/home'
-wsize = '1m'
-period = '5'
+disk = /home
+wsize = 1m
+period = 5 # Treated as int
+io_type.cache_io.mode= -C
+*.fs_type.*.exclude = 1-500
+flag = False # Treated as bool
+
+# All others are treated as strings
+# Note that quotes are not necessary

--- a/lib/helper.py
+++ b/lib/helper.py
@@ -182,3 +182,30 @@ def remove_file(src, dest):
         if os.path.exists(d_file):
             os.remove(d_file)
         logger.debug("%s file deleted" % d_file)
+
+
+def keys_exists(element, *keys):
+    '''
+    Check if *keys (nested) exists in `element` (dict).
+    '''
+    _element = element
+    for key in keys:
+        try:
+            _element = _element[key]
+        except KeyError:
+            return False
+    return True
+
+
+def deep_put(items, data, value):
+    """
+    Assign value in dictionary with multi level nested keys
+    """
+    item = items.pop(0)
+    if items:
+        next_item = {}
+        if not data.get(item):
+            data[item] = next_item
+        deep_put(items, data[item], value)
+    else:
+        data[item] = value

--- a/lib/helper.py
+++ b/lib/helper.py
@@ -188,13 +188,20 @@ def keys_exists(element, *keys):
     '''
     Check if *keys (nested) exists in `element` (dict).
     '''
+    st_json = []
     _element = element
-    for key in keys:
+    for cnt, key in enumerate(keys):
+        if key == "*" and cnt != len(keys) - 1:
+            # Check first key alone for existence
+            key = next(iter(_element))
+            st_json.append({cnt: list(_element.keys())})
         try:
             _element = _element[key]
         except KeyError:
-            return False
-    return True
+            return [], False
+        except TypeError:
+            return [], False
+    return st_json, True
 
 
 def deep_put(items, data, value):

--- a/lib/yaml_helper.py
+++ b/lib/yaml_helper.py
@@ -1,0 +1,66 @@
+import yaml
+
+
+class OverrideConstructor(yaml.constructor.SafeConstructor):
+    def __init__(self):
+        yaml.constructor.SafeConstructor.__init__(self)
+
+    def construct_undefined(self, node):
+        data = getattr(self, 'construct_' + node.id)(node)
+        datatype = type(data)
+        wraptype = type('TagWrap_'+datatype.__name__, (datatype,), {})
+        wrapdata = wraptype(data)
+        wrapdata.tag = lambda: None
+        wrapdata.datatype = lambda: None
+        setattr(wrapdata, "wrapTag", node.tag)
+        setattr(wrapdata, "wrapType", datatype)
+        return wrapdata
+
+
+class OverrideLoader(OverrideConstructor, yaml.loader.SafeLoader):
+
+    def __init__(self, stream):
+        OverrideConstructor.__init__(self)
+        yaml.loader.SafeLoader.__init__(self, stream)
+
+
+class OverrideRepresenter(yaml.representer.SafeRepresenter):
+    def represent_data(self, wrapdata):
+        tag = False
+        if type(wrapdata).__name__.startswith('TagWrap_'):
+            datatype = getattr(wrapdata, "wrapType")
+            tag = getattr(wrapdata, "wrapTag")
+            data = datatype(wrapdata)
+        else:
+            data = wrapdata
+        node = super(OverrideRepresenter, self).represent_data(data)
+        if tag:
+            node.tag = tag
+        return node
+
+
+class OverrideDumper(OverrideRepresenter, yaml.dumper.SafeDumper):
+
+    def __init__(self, stream, default_style=None, default_flow_style=False,
+                 canonical=None, indent=None, width=None, allow_unicode=None,
+                 line_break=None, encoding=None, explicit_start=None,
+                 explicit_end=None, version=None, tags=None, sort_keys=True):
+
+        OverrideRepresenter.__init__(self, default_style=default_style,
+                                     default_flow_style=default_flow_style,
+                                     sort_keys=sort_keys)
+
+        yaml.dumper.SafeDumper.__init__(self, stream,
+                                        default_style=default_style,
+                                        default_flow_style=default_flow_style,
+                                        canonical=canonical,
+                                        indent=indent,
+                                        width=width,
+                                        allow_unicode=allow_unicode,
+                                        line_break=line_break,
+                                        encoding=encoding,
+                                        explicit_start=explicit_start,
+                                        explicit_end=explicit_end,
+                                        version=version,
+                                        tags=tags,
+                                        sort_keys=sort_keys)


### PR DESCRIPTION
The previous implementation had a limitation of not being able to specify values to leaves with same name of different parent nodes. This patch adds support to enable providing input at leaf level
through dotted notation.

Eg:
**YAML**
```
setup:
  disk:
  disk_type:
    type: nvdimm
  fs_type: !mux
    fs_ext4:
      fs: ext4
      mkfs_opt: -b 65536
    fs_xfs:
      fs: xfs
      mkfs_opt: -b size=64k
```
**input.txt**
```
setup.disk="/dev/sda2"
setup.fs_type.fs_ext4.mkfs_opt="-b 64k"
setup.fs_type.fs_xfs.mkfs_opt="-b size=64k -ssize=4k"
```

Signed-off-by: Harish <harish@linux.ibm.com>