### PR TITLE
sysinfo: Adding fail_commands file

### DIFF
--- a/avocado-setup.py
+++ b/avocado-setup.py
@@ -295,8 +295,12 @@ def create_config(logdir):
     config.add_section('sysinfo.collectibles')
     config.set('sysinfo.collectibles', 'commands',
                os.path.join(BASE_PATH, "config/sysinfo/commands"))
+    config.set('sysinfo.collectibles', 'fail_commands',
+               os.path.join(BASE_PATH, "config/sysinfo/fail_commands"))
     config.set('sysinfo.collectibles', 'files',
                os.path.join(BASE_PATH, "config/sysinfo/files"))
+    config.set('sysinfo.collectibles', 'fail_files',
+               os.path.join(BASE_PATH, "config/sysinfo/fail_files"))
     config.set('sysinfo.collectibles', 'profilers',
                os.path.join(BASE_PATH, "config/sysinfo/profilers"))
 

--- a/config/sysinfo/fail_commands
+++ b/config/sysinfo/fail_commands
@@ -1,0 +1,2 @@
+sosreport --batch --tmp-dir $AVOCADO_SYSINFODIR
+supportconfig -R $AVOCADO_SYSINFODIR


### PR DESCRIPTION
Adding fail_commands file, which runs on post whenever a test
fails. Populating it with sosreport and supportconfig.

This feature was added to avocado via:
https://github.com/avocado-framework/avocado/pull/3923

Signed-off-by: Narasimhan V <sim@linux.vnet.ibm.com>