### PR TITLE
Update kvm upstream test bucket

### DIFF
--- a/config/tests/guest/libvirt/upstream.cfg
+++ b/config/tests/guest/libvirt/upstream.cfg
@@ -43,9 +43,14 @@ emulator_path=/usr/share/avocado-plugins-vt/bin/qemu
 kernel=/home/kvmci/linux/vmlinux
 initrd=''
 use_serial_login=yes
+test_timeout = 72000
+
 variants:
-    - upstreamtest:
-        only file_transfer.default_setting
+    - vmstart:
+        only boot
+        no virsh.boot
+        only virtio_net
+        only qcow2
         variants:
             - @:
             - with_numa:
@@ -74,30 +79,17 @@ variants:
                         numa_mem_node3="2097152"
                         numa_cpus_node3="6-7"
                         numa_nodeid_node3="3"
-                    - with_memless_node:
-                        numa_mem_node0="2097152"
-                        numa_cpus_node0="0-1"
-                        numa_nodeid_node0="0"
-                        numa_mem_node1="0"
-                        numa_cpus_node1="2-3"
-                        numa_nodeid_node1="1"
-                        numa_mem_node2="4194304"
-                        numa_cpus_node2="4-5"
-                        numa_nodeid_node2="2"
-                        numa_mem_node3="2097152"
-                        numa_cpus_node3="6-7"
-                        numa_nodeid_node3="3"
                     - asymmetric_nodes:
-                        numa_mem_node0="0"
+                        numa_mem_node0="1048576"
                         numa_cpus_node0="1,3,7"
                         numa_nodeid_node0="0"
-                        numa_mem_node1="0"
+                        numa_mem_node1="2097152"
                         numa_cpus_node1="0,4-5"
                         numa_nodeid_node1="1"
-                        numa_mem_node2="0"
+                        numa_mem_node2="2097152"
                         numa_cpus_node2="2"
                         numa_nodeid_node2="2"
-                        numa_mem_node3="8388608"
+                        numa_mem_node3="3145728"
                         numa_cpus_node3="6"
                         numa_nodeid_node3="3"
         variants:
@@ -144,7 +136,7 @@ variants:
                 vcpu_sockets=1
             - with_lowmem:
                 no with_numa
-                mem=512
+                mem=2048
             - with_singlecpu:
                 only with_smt1
                 smp=1
@@ -185,6 +177,7 @@ variants:
                         virtinstall_qemu_cmdline_vm7=" -M pseries,ic-mode=xics,kernel-irqchip=off"
                         virtinstall_qemu_cmdline_vm8=" -M pseries,ic-mode=dual,max-cpu-compat=power8,kernel-irqchip=off"
             - with_vsmt:
+                mem = 20480
                 no with_intc,mem_merge,with_numa
                 only with_smt1
                 vms = "vm1 vm2 vm3 vm4"
@@ -233,10 +226,10 @@ variants:
                         virtinstall_qemu_cmdline_vm6=" -M pseries,ic-mode=xive,kernel-irqchip=off,mem-merge=False"
                         virtinstall_qemu_cmdline_vm7=" -M pseries,ic-mode=xics,kernel-irqchip=off,mem-merge=False"
                         virtinstall_qemu_cmdline_vm8=" -M pseries,ic-mode=dual,max-cpu-compat=power8,kernel-irqchip=off,mem-merge=False"
-            #- with_nested_cap:
-            #    no with_vsmt,with_intc,mem_merge
-            #    only with_smt4
-            #    virtinstall_qemu_cmdline_vm1=" -M pseries,cap-nested-hv=True"
+            - with_nested_cap:
+                no with_vsmt,with_intc,mem_merge
+                only with_smt4,with_smt8
+                virtinstall_qemu_cmdline_vm1=" -M pseries,cap-nested-hv=True"
         variants:
             - with_virtio_scsi:
                 kernel_args='root=/dev/sda2 rw console=tty0 console=ttyS0,115200 init=/sbin/init initcall_debug selinux=0'
@@ -246,5 +239,87 @@ variants:
                 kernel_args='root=/dev/vda2 rw console=tty0 console=ttyS0,115200 init=/sbin/init initcall_debug selinux=0'
                 no with_virtio_scsi
                 only virtio_blk
-only virtio_net
-only qcow2
+
+    - vm:
+        kernel_args='root=/dev/sda2 rw console=tty0 console=ttyS0,115200 init=/sbin/init initcall_debug selinux=0'
+        only virtio_scsi
+        only virtio_net
+        only qcow2
+        variants:
+            - tests:
+                variants:
+                    - memory:
+                        only avocado_guest.memhotplug,avocado_guest.eatmemory,avocado_guest.memintegrity
+                    - generic:
+                        only smallpages
+                        only avocado_guest.ltp,avocado_guest.kselftest
+                    - cpu:
+                        only smallpages
+                        vcpu_cores = 4
+                        vcpu_threads = 8
+                        vcpu_sockets =  1
+                        vcpu_maxcpus = 32
+                        only avocado_guest.ebizzy,avocado_guest.ppc64_cpu_test
+                    - io:
+                        vcpu_cores = 16
+                        vcpu_threads = 2
+                        vcpu_sockets =  1
+                        vcpu_maxcpus = 32
+                        only avocado_guest.fiotest
+
+            - guestdump:
+                only virsh.dump.positive_test.non_acl.live_dump
+            - diskhotplug:
+                at_dt_disk_device_target = sdb
+                only virsh.attach_detach_disk_matrix..at_option_live
+                no dt_option_live_config,dt_option_config,dt_option_default,dt_option_live_config,at_okay_dt_error,at_error_dt_error,pre_vm_state_shutoff,pre_vm_state_paused,pre_vm_state_transient,dt_option_current
+            - memoryhotplug:
+                only libvirt_mem.positive_test.memory.hot.unplug.max_slots.with_rand_reboot
+            - vcpuhotplug:
+                start_vm = yes
+                test_itr = 2
+                mem = 81920
+                vcpu_max_timeout = 480
+                vcpu_sockets =  1
+                vcpu_maxcpus = 64
+                topology_correction = "no"
+                variants:
+                    - 1thread:
+                        no hugepages
+                        vcpu_cores = 64
+                        smp = 1
+                        vcpu_threads = 1
+                        vcpu_current_num = 1
+                        vcpu_plug_num = 64
+                        vcpu_unplug_num = 1
+                        vcpu_max_num = 64
+                        only libvirt_vcpu_plug_unplug..with_maxvcpu
+                    - 2threads:
+                        no hugepages
+                        smp = 2
+                        vcpu_cores = 32
+                        vcpu_threads = 2
+                        vcpu_current_num = 2
+                        vcpu_plug_num = 64
+                        vcpu_unplug_num = 2
+                        vcpu_max_num = 64
+                        only libvirt_vcpu_plug_unplug..with_maxvcpu
+                    - 4threads:
+                        smp = 4
+                        vcpu_cores = 16
+                        vcpu_threads = 4
+                        vcpu_current_num = 4
+                        vcpu_plug_num = 64
+                        vcpu_unplug_num = 4
+                        vcpu_max_num = 64
+                        only libvirt_vcpu_plug_unplug..with_maxvcpu
+                    - 8threads:
+                        no hugepages
+                        smp = 8
+                        vcpu_cores = 8
+                        vcpu_threads = 8
+                        vcpu_current_num = 8
+                        vcpu_plug_num = 64
+                        vcpu_unplug_num = 8
+                        vcpu_max_num = 64
+                        only libvirt_vcpu_plug_unplug..with_maxvcpu


### PR DESCRIPTION
Update guesttests and vm features tests
like vcpu hotplug, memory hotplug etc.

Update nested machine property test.

Remove numa memoryless node tests as
it got deprecated in recent qemu, libvirt builds.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>