### PR TITLE
Enable leaf level input for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,13 @@ $ ./avocado-setup.py -h
     >It contains 1 yaml file,namely [ioping.yaml](https://github.com/avocado-framework-tests/avocado-misc-tests/blob/master/io/disk/ioping.py.data/ioping.yaml)
     Now, it has yaml parameters like mode, count, deadline, period, disk, etc.
     Suppose user wants to change only 3 of those values, say disk, wsize and period, user can have that alone in our input file.
-    Refer [input_example.txt](input_example.txt) for this example.
+    User must specify config key value matching the branch of the yaml through "/" notation (matching yaml_to_mux.parameter_paths).
+    Optinally users can also provide input with '*' as part of config key, if the config key needs to be matched irrespective for multiple branches.
+    Please note that only strings where you want to enforce strictly as string must be enclosed in double-quotes only, like numbers, expressions, lists, etc. Normal strings need not be enclosed in double-quotes.
+    Example:
+    "1", if 1 needs to be strictly read as string
+    1, if 1 needs to be read as integer
+    Refer [input_example.txt](input_example.txt) for details.
 
 
 5. `--verbose`:

--- a/input_example.txt
+++ b/input_example.txt
@@ -1,4 +1,7 @@
 [example]
-disk = '/home'
-wsize = '1m'
-period = '5'
+disk = /home
+wsize = 1m
+period = 5
+setup/fs_type/fs_xfs/exclude = "83,113,136"
+setup/fs_type/*/gen_exclude = 232
+config/preserve_change = False


### PR DESCRIPTION
The previous implementation had a limitation of not being able to specify values to leaves with same name of different parent nodes in a single yaml file. This patch adds support to enable providing input at leaf level through / notation.

Eg:
YAML
----
setup:
  disk:
  disk_type:
    type: nvdimm
  fs_type: !mux
    fs_ext4:
      fs: ext4
      mkfs_opt: -b 65536
    fs_xfs:
      fs: xfs
      mkfs_opt: -b size=64k

input.txt
---------
/setup/disk="/dev/sda2"
/setup/fs_type/fs_ext4/mkfs_opt="-b 64k"
/setup/fs_type/fs_xfs/mkfs_opt="-b size=64k -ssize=4k"

It also supports inputs for fields with different parent branch.
This is achieved using special character * indicating any.

Two different yaml will be updated in the following way.

/*/fs_type/fs_xfs/gen_exclude matching:
/setup/fs_type/fs_xfs/gen_exclude
/config/fs_type/fs_xfs/gen_exclude

1.yaml
------
setup:
  fs_type: !mux
    fs_ext4:
      exclude: 83,113,136,305,363,442
      fs: ext4
      gen_exclude: 1-387,389-600
      mkfs_opt: -b 65536
    fs_xfs:
      exclude: 83,113,136,305,363,442
      fs: xfs
      gen_exclude: 232,234,270,530,531,585
      mkfs_opt: -b size=65536 -s size=4096 -m reflink=0

2.yaml
------
config:
  fs_type: !mux
    fs_xfs:
      exclude: 83,113,136,305,363,442
      fs: xfs
      gen_exclude: 232,234,270,530,531,585

Signed-off-by: Harish <harish@linux.ibm.com>