### PR TITLE
removing obsolete commands from config/sysinfo/commands file

### DIFF
--- a/config/sysinfo/commands
+++ b/config/sysinfo/commands
@@ -6,9 +6,8 @@ gcc --version
 ld --version
 hostname
 uptime
-dmidecode
-ifconfig -a
-brctl show
+ip a
+ip -d link show 
 ip link
 numactl --hardware show
 lscpu


### PR DESCRIPTION
commands like dmidecode, brct, ifconfig are obsolete on latest distros

Signed-off-by: Vaishnavi Bhat <vaishnavi@linux.vnet.ibm.com>