### PR TITLE
Add support to install framework using pip and user defined version and refactor bootstrap and env clean

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,9 @@ $ ./avocado-setup.py -h
     > Force wrapper to skip check for dependancy packages.  This helps to save time when re-running tests on a system where prereqs have already been checked once.
 
 14. `--clean`:
-    > Remove/Uninstall autotest and avocado from system after test completion.
+    > Remove/Uninstall autotest and avocado from system after test completion.<br>
+    >
+    > USE IT WITH CAUTION: When this option used alone(i.e ./avocado-setup.py --clean), this will remove even the avocado config and data directory(includes guest images) and tests directoty.
 
 15. `--enable-kvm`:
     > By default kvm(guest VM) tests environment is not bootstrapped, enable this flag to bootstrap KVM (guest VM) tests.

--- a/config/wrapper/env.conf
+++ b/config/wrapper/env.conf
@@ -1,7 +1,14 @@
-[repo]
-avocado = https://github.com/avocado-framework/avocado.git
-avocado_vt = https://github.com/avocado-framework/avocado-vt.git
-tests = https://github.com/avocado-framework-tests/avocado-misc-tests.git
+[framework]
+# Usage examples:
+# (avocado-framework, '')  -- Installs latest released version
+# ('avocado-framework', 80.0)  -- Installs specificed version, make sure you change other entries aswell
+# ('avocado-framework', 'git+https://github.com/avocado-framework/avocado.git') -- Install version from the given git repo
+base = [('avocado-framework', ''), ('avocado-framework-plugin-varianter-yaml-to-mux', '')]
+kvm = [('avocado-framework-plugin-vt', '')]
+optional = [('avocado-framework-plugin-result-html', '')]
+
+[tests]
+name = ['https://github.com/avocado-framework-tests/avocado-misc-tests.git']
 
 [deps_centos]
 packages = gcc,python3-devel,python3-setuptools,numactl,policycoreutils-python
@@ -135,9 +142,6 @@ packages =
 packages =
 [deps_slesbe12_kvm]
 packages =
-
-[plugins]
-optional = html,varianter_yaml_to_mux
 
 [pip-package]
 package = configparser,enum


### PR DESCRIPTION
Lately, we are noticing lot of issues due to broken framework
in the environment using the unmatching version across different
plugins, so let's avoid the direct repo install and use standard
pip installation for framework and its plugin, by default it will
install the latest released version of framework if bootstrapped,
having said that user could choose the different version than
default as needed through config and use the git repo aswell,
details of how to choose different config options are documented
in the config file comment section.

Refactored the bootstrap workflow and env clean to have the
proper environment to start with and clean the environment properly
when asked, earlier unwanted steps were run.

miscellaneous pylint fixes.

Signed-off-by: Satheesh Rajendran <sathnaga@linux.vnet.ibm.com>