### PR TITLE
Adding enchant package in RHEL8 depedency

### DIFF
--- a/config/wrapper/env.conf
+++ b/config/wrapper/env.conf
@@ -53,9 +53,9 @@ packages = p7zip,libvirt-devel,tcpdump,virt-install,qemu,libvirt,SLOF,genisoimag
 [deps_rhel8]
 packages = gcc,python36-devel,xz-devel,python3-setuptools,numactl,policycoreutils-python-utils,openssl-devel
 [deps_rhel8_NV]
-packages =
+packages = enchant
 [deps_rhel8_pHyp]
-packages =
+packages = enchant
 [deps_rhel8_kvm]
 packages = libvirt-devel,tcpdump,virt-install,qemu-kvm,libvirt,SLOF,genisoimage,attr
 [deps_rhelbe]


### PR DESCRIPTION
Adding enchant package in RHEL8 depedency, It is required while installing Avocado on RHEL 8 
hence adding the package to RHEL list 

Signed-off by: Spoorthy<spoorthy@linux.vnet.ibm.com>