### PR TITLE
Fix tests repo name check

### DIFF
--- a/avocado-setup.py
+++ b/avocado-setup.py
@@ -189,7 +189,7 @@ def need_bootstrap(enable_kvm=False):
                 needs_bootstrap = True
     # Check for avocado-tests
     for repo in TEST_REPOS:
-        repo_name = repo.split('/')[-1].split('.')[0]
+        repo_name = repo[0].split('/')[-1].split('.')[0]
         if not os.path.isdir(os.path.join(TEST_DIR, repo_name)):
             logger.debug("Test needs to be downloaded/updated")
             needs_bootstrap = True


### PR DESCRIPTION
With the recent changes to the input being a tuple, the check for tests repo name fails. This patch fixes the tests repo name check

Signed-off-by: Harish <harish@linux.ibm.com>