### PR TITLE
vSCSI test bucket and input file template

### DIFF
--- a/config/inputs/io_vscsi_input.txt
+++ b/config/inputs/io_vscsi_input.txt
@@ -1,0 +1,13 @@
+[io_vscsi]
+iteration = 10
+disk = "/dev/sdb"
+disks = "/dev/sdb /dev/sdc /dev/sdd /dev/sde"
+dir = "/mnt"
+lv_disks = "/dev/dev/sdb"
+lv_size = "40G"
+module = "ibmvscsi"
+count = 10
+fsstress_loop = 2
+num_of_dlpar = 10
+htx_disks = "/dev/sdb /dev/sdc /dev/sdd /dev/sde"
+time_limit = 30

--- a/config/tests/host/io_vscsi.cfg
+++ b/config/tests/host/io_vscsi.cfg
@@ -1,0 +1,19 @@
+avocado-misc-tests/io/disk/lvsetup.py avocado-misc-tests/io/disk/lvsetup.py.data/lvsetup.yaml "--execution-order tests-per-variant"
+avocado-misc-tests/io/disk/ltp_fs.py avocado-misc-tests/io/disk/ltp_fs.py.data/ltp_fs.yaml "--execution-order tests-per-variant"
+avocado-misc-tests/io/disk/ltp_fsstress.py avocado-misc-tests/io/disk/ltp_fsstress.py.data/ltp_fsstress.yaml
+avocado-misc-tests/io/disk/dbench.py avocado-misc-tests/io/disk/dbench.py.data/dbench.yaml
+avocado-misc-tests/io/disk/disk_info.py avocado-misc-tests/io/disk/disk_info.py.data/disk_info.yaml
+avocado-misc-tests/io/disk/disktest.py avocado-misc-tests/io/disk/disktest.py.data/disktest.yaml
+avocado-misc-tests/io/disk/ioping.py avocado-misc-tests/io/disk/ioping.py.data/ioping.yaml
+avocado-misc-tests/io/disk/parallel_dd.py avocado-misc-tests/io/disk/parallel_dd.py.data/parallel_dd.yaml
+avocado-misc-tests/io/disk/rawread.py avocado-misc-tests/io/disk/rawread.py.data/rawread.yaml
+avocado-misc-tests/io/disk/smartctl.py avocado-misc-tests/io/disk/smartctl.py.data/smartctl.yaml
+avocado-misc-tests/io/common/bootlist_test.py avocado-misc-tests/io/common/bootlist_test.py.data/bootlist_test_disk.yaml
+avocado-misc-tests/io/disk/fiotest.py avocado-misc-tests/io/disk/fiotest.py.data/fio.yaml
+avocado-misc-tests/io/disk/tiobench.py avocado-misc-tests/io/disk/tiobench.py.data/tiobench.yaml
+avocado-misc-tests/io/disk/bonnie.py avocado-misc-tests/io/disk/bonnie.py.data/bonnie.yaml
+avocado-misc-tests/io/disk/iozone.py avocado-misc-tests/io/disk/iozone.py.data/iozone.yaml
+avocado-misc-tests/io/disk/fs_mark.py avocado-misc-tests/io/disk/fs_mark.py.data/fs_mark.yaml
+avocado-misc-tests/io/disk/htx_block_devices.py:HtxTest.test_start avocado-misc-tests/io/disk/htx_block_devices.py.data/htx_block_devices.yaml
+avocado-misc-tests/io/disk/htx_block_devices.py:HtxTest.test_check avocado-misc-tests/io/disk/htx_block_devices.py.data/htx_block_devices.yaml
+avocado-misc-tests/io/disk/htx_block_devices.py:HtxTest.test_stop avocado-misc-tests/io/disk/htx_block_devices.py.data/htx_block_devices.yaml


### PR DESCRIPTION
Added virtual SCSI block device test bucket io_vscsi.cfg and input file
io_vscsi_input.txt format

Signed-off-by: Abdul Haleem <abdhalee@linux.vnet.ibm.com>