### PR TITLE
Replaced package name with its python3 correspondent

### DIFF
--- a/config/wrapper/env.conf
+++ b/config/wrapper/env.conf
@@ -13,7 +13,7 @@ optional = [('avocado-framework-plugin-result-html', '')]
 name = [('https://github.com/avocado-framework-tests/avocado-misc-tests.git', '')]
 
 [deps_centos]
-packages = gcc,python3-devel,python3-setuptools,numactl,policycoreutils-python
+packages = gcc,python3-devel,python3-setuptools,numactl,python3-policycoreutils
 [deps_centos_NV]
 packages =
 [deps_centos_pHyp]


### PR DESCRIPTION
Description: config file was looking for the package with the old name. Modified it to look for its python3 correspondent name.

Signed-off By: Kowshik Jois<kowsjois@linux.ibm.com>
Tested By: Kowshik Jois<kowsjois@linux.ibm.com>