### PR TITLE
replaced genisoimage with xorriso for centos9

### DIFF
--- a/config/wrapper/env.conf
+++ b/config/wrapper/env.conf
@@ -13,13 +13,17 @@ optional = [('avocado-framework-plugin-result-html', '')]
 name = [('https://github.com/avocado-framework-tests/avocado-misc-tests.git', '')]
 
 [deps_centos]
-packages = gcc,python3-devel,python3-setuptools,numactl,python3-policycoreutils
+packages = gcc,python3-devel,python3-setuptools,numactl,policycoreutils-python
+[deps_centos9]
+packages = gcc,python3-devel,python3-setuptools,numactl,policycoreutils-python
 [deps_centos_NV]
 packages =
 [deps_centos_pHyp]
 packages =
 [deps_centos_kvm]
 packages = p7zip,libvirt-devel,tcpdump,virt-install,qemu,libvirt,SLOF,genisoimage,attr
+[deps_centos9_kvm]
+packages = p7zip,libvirt-devel,tcpdump,virt-install,qemu,libvirt,SLOF,xorriso,attr
 [deps_ubuntu]
 packages = gcc,python3-dev,python3-setuptools,numactl
 [deps_ubuntu_NV]


### PR DESCRIPTION
Description: since RHEL9.0, the genisoimage package has been replaced by the xorriso package, which provides the genisoimage command previously provided by the genisoimage package.

source: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/pdf/considerations_in_adopting_rhel_9/red_hat_enterprise_linux-9-considerations_in_adopting_rhel_9-en-us.pdf (Page 104)

Signed-off-by: Kowshik Jois B S <kowsjois@linux.ibm.com>
Tested-by: Kowshik Jois B S <kowsjois@linux.ibm.com>