### PR TITLE
remove unsupported dompmsuspend testcases from sanity bucket

### DIFF
--- a/config/tests/guest/libvirt/sanity.cfg
+++ b/config/tests/guest/libvirt/sanity.cfg
@@ -310,8 +310,6 @@ variants:
                     - domstats:
                         vm_list = ${vms}
                         only virsh.domstats.normal_test.domain_state.active.no_option.specific_domain,virsh.domstats.error_test.extra_option
-                    - dompmsuspend:
-                        only virsh.dompmsuspend.positive_test.non_acl.mem,virsh.dompmsuspend.negative_test.vm_paused
                     - domfsthaw:
                         only virsh.domfsthaw.positive_tests.full_freeze,virsh.domfsthaw.negative_tests.not_active_domain
                     - domdisplay:


### PR DESCRIPTION
Signed-off-by: Kowshik Jois B S <kowsjois@linux.ibm.com>