### PR TITLE
remove unsupported domxml-native test

### DIFF
--- a/config/tests/guest/libvirt/sanity.cfg
+++ b/config/tests/guest/libvirt/sanity.cfg
@@ -273,8 +273,6 @@ variants:
                         only virsh.domstate.normal_test.id_option,virsh.domstate.error_test.no_option
                     - domuuid:
                         only virsh.domuuid.normal_test.vm_running.valid_domid,virsh.domuuid.error_test.invalid_domid
-                    - domxml-native:
-                        only virsh.domxml_to_native.no_option,virsh.domxml_to_native.invalid_format_option,virsh.domxml_from_native.expect_option
                     - dumpxml:
                         only virsh.dumpxml.normal_test.non_acl.vm_shutoff.with_default.domuuid,virsh.dumpxml.error_test.none_domain
                     - edit:


### PR DESCRIPTION
Signed-off-by: Kowshik Jois B S <kowsjois@linux.ibm.com>

Since libvirt v5.5.0(2019-07-02) qemu: Remove support for virDomainQemuAttach and virConnectDomainXMLFromNative APIs(https://libvirt.org/news.html).