### PR TITLE
host/io: Update cfg files to include pci_lsvpd tests

### DIFF
--- a/config/tests/host/io_fc.cfg
+++ b/config/tests/host/io_fc.cfg
@@ -14,7 +14,7 @@ avocado-misc-tests/io/disk/lvsetup.py avocado-misc-tests/io/disk/lvsetup.py.data
 avocado-misc-tests/io/disk/multipath_test.py avocado-misc-tests/io/disk/multipath_test.py.data/multipath_test.yaml
 avocado-misc-tests/io/disk/parallel_dd.py avocado-misc-tests/io/disk/parallel_dd.py.data/parallel_dd.yaml
 avocado-misc-tests/io/disk/rawread.py avocado-misc-tests/io/disk/rawread.py.data/rawread.yaml
-avocado-misc-tests/io/pci/pci_info_lsvpd.py
+avocado-misc-tests/ras/ras_lsvpd.py:RASToolsLsvpd.test_pci_lsvpd
 avocado-misc-tests/io/disk/smartctl.py avocado-misc-tests/io/disk/smartctl.py.data/smartctl.yaml
 avocado-misc-tests/io/disk/softwareraid.py avocado-misc-tests/io/disk/softwareraid.py.data/softwareraid.yaml
 avocado-misc-tests/io/disk/tiobench.py avocado-misc-tests/io/disk/tiobench.py.data/tiobench.yaml

--- a/config/tests/host/io_infiniband_fvt.cfg
+++ b/config/tests/host/io_infiniband_fvt.cfg
@@ -8,7 +8,7 @@ avocado-misc-tests/io/net/multiport_stress.py avocado-misc-tests/io/net/multipor
 avocado-misc-tests/io/driver/driver_bind_test.py avocado-misc-tests/io/driver/driver_bind_test.py.data/driver_bind_test.yaml
 avocado-misc-tests/io/driver/module_unload_load.py avocado-misc-tests/io/driver/module_unload_load.py.data/module_unload_load.yaml
 avocado-misc-tests/io/pci/pci_hotplug.py avocado-misc-tests/io/pci/pci_hotplug.py.data/pci_hotplug.yaml
-avocado-misc-tests/io/pci/pci_info_lsvpd.py
+avocado-misc-tests/ras/ras_lsvpd.py:RASToolsLsvpd.test_pci_lsvpd
 avocado-misc-tests/io/net/infiniband/ib_pingpong.py avocado-misc-tests/io/net/infiniband/ib_pingpong.py.data/ib_pingpong_infiniband.yaml
 avocado-misc-tests/io/net/infiniband/ucmatose.py avocado-misc-tests/io/net/infiniband/ucmatose.py.data/ucmatose_infiniband.yaml
 avocado-misc-tests/io/net/infiniband/ping6.py avocado-misc-tests/io/net/infiniband/ping6.py.data/ping6_infiniband.yaml

--- a/config/tests/host/io_network.cfg
+++ b/config/tests/host/io_network.cfg
@@ -11,7 +11,7 @@ avocado-misc-tests/io/net/tcpdump.py avocado-misc-tests/io/net/tcpdump.py.data/t
 avocado-misc-tests/io/net/bonding.py avocado-misc-tests/io/net/bonding.py.data/bonding.yaml "--execution-order tests-per-variant"
 avocado-misc-tests/io/net/bridge.py avocado-misc-tests/io/net/bridge.py.data/bridge.yaml
 avocado-misc-tests/io/net/htx_nic_devices.py avocado-misc-tests/io/net/htx_nic_devices.py.data/htx_nic_devices.yaml
-avocado-misc-tests/io/pci/pci_info_lsvpd.py
+avocado-misc-tests/ras/ras_lsvpd.py:RASToolsLsvpd.test_pci_lsvpd
 avocado-misc-tests/io/pci/dlpar.py avocado-misc-tests/io/pci/dlpar.py.data/dlpar.yaml
 avocado-misc-tests/io/pci/pci_hotplug.py avocado-misc-tests/io/pci/pci_hotplug.py.data/pci_hotplug.yaml
 avocado-misc-tests/io/pci/distro_tools.py avocado-misc-tests/io/pci/distro_tools.py.data/distro_tools.yaml

--- a/config/tests/host/io_nvme_fvt.cfg
+++ b/config/tests/host/io_nvme_fvt.cfg
@@ -1,4 +1,4 @@
-avocado-misc-tests/io/pci/pci_info_lsvpd.py
+avocado-misc-tests/ras/ras_lsvpd.py:RASToolsLsvpd.test_pci_lsvpd
 avocado-misc-tests/io/pci/pci_hotplug.py avocado-misc-tests/io/pci/pci_hotplug.py.data/pci_hotplug.yaml
 avocado-misc-tests/io/driver/driver_bind_test.py avocado-misc-tests/io/driver/driver_bind_test.py.data/driver_bind_test.yaml
 avocado-misc-tests/io/disk/softwareraid.py avocado-misc-tests/io/disk/softwareraid.py.data/softwareraid.yaml

--- a/config/tests/host/io_roce_fvt.cfg
+++ b/config/tests/host/io_roce_fvt.cfg
@@ -6,7 +6,7 @@ avocado-misc-tests/io/driver/driver_bind_test.py avocado-misc-tests/io/driver/dr
 avocado-misc-tests/io/driver/module_unload_load.py avocado-misc-tests/io/driver/module_unload_load.py.data/module_unload_load.yaml
 avocado-misc-tests/io/driver/driver_parameter.py avocado-misc-tests/io/driver/driver_parameter.py.data/driver_parameter_mlx5_core_roce.yaml
 avocado-misc-tests/io/pci/pci_hotplug.py avocado-misc-tests/io/pci/pci_hotplug.py.data/pci_hotplug.yaml
-avocado-misc-tests/io/pci/pci_info_lsvpd.py
+avocado-misc-tests/ras/ras_lsvpd.py:RASToolsLsvpd.test_pci_lsvpd
 avocado-misc-tests/io/net/infiniband/udaddy.py avocado-misc-tests/io/net/infiniband/udaddy.py.data/udaddy_roce.yaml
 avocado-misc-tests/io/net/infiniband/ucmatose.py avocado-misc-tests/io/net/infiniband/ucmatose.py.data/ucmatose_roce.yaml
 avocado-misc-tests/io/net/infiniband/ping6.py avocado-misc-tests/io/net/infiniband/ping6.py.data/ping6_roce.yaml

--- a/config/tests/host/io_roce_mlx4_fvt.cfg
+++ b/config/tests/host/io_roce_mlx4_fvt.cfg
@@ -5,7 +5,7 @@ avocado-misc-tests/io/common/distro_tools.py avocado-misc-tests/io/common/distro
 avocado-misc-tests/io/driver/driver_bind_test.py avocado-misc-tests/io/driver/driver_bind_test.py.data/driver_bind_test.yaml
 avocado-misc-tests/io/driver/module_unload_load.py avocado-misc-tests/io/driver/module_unload_load.py.data/module_unload_load.yaml
 avocado-misc-tests/io/pci/pci_hotplug.py avocado-misc-tests/io/pci/pci_hotplug.py.data/pci_hotplug.yaml
-avocado-misc-tests/io/pci/pci_info_lsvpd.py
+avocado-misc-tests/ras/ras_lsvpd.py:RASToolsLsvpd.test_pci_lsvpd
 avocado-misc-tests/io/net/infiniband/udaddy.py avocado-misc-tests/io/net/infiniband/udaddy.py.data/udaddy_roce.yaml
 avocado-misc-tests/io/net/infiniband/ucmatose.py avocado-misc-tests/io/net/infiniband/ucmatose.py.data/ucmatose_roce.yaml
 avocado-misc-tests/io/net/infiniband/ping6.py avocado-misc-tests/io/net/infiniband/ping6.py.data/ping6_roce.yaml


### PR DESCRIPTION
commit 09666db835 from avocado-misc-tests repository removed
pci_info_lsvpd test from io. Update the corresponding cfg files to
reflect the new test

Signed-off-by: Sachin Sant <sachinp@linux.ibm.com>