### PR TITLE
Adding minimum sanity bucket for kernel test

### DIFF
--- a/config/tests/host/sanity_min.cfg
+++ b/config/tests/host/sanity_min.cfg
@@ -1,0 +1,1 @@
+avocado-misc-tests/kernel/kselftest.py avocado-misc-tests/kernel/kselftest.py.data/kselftest_powerpc.yaml


### PR DESCRIPTION
kselftest for powerpc is used here to run minimum sanity on kernel. This bucket takes ~20 minutes to complete the test.
The tests are added in PR - https://github.com/avocado-framework-tests/avocado-misc-tests/pull/2527

Signed-off-by:Spoorthy S<spoorts2@in.ibm.com>