### PR TITLE
Add config file for tracing tests

### DIFF
--- a/config/tests/host/distro_trace.cfg
+++ b/config/tests/host/distro_trace.cfg
@@ -1,0 +1,4 @@
+avocado-misc-tests/kernel/kselftest.py avocado-misc-tests/kernel/kselftest.py.data/ftracetest.yaml
+avocado-misc-tests/kernel/kselftest.py avocado-misc-tests/kernel/kselftest.py.data/ptrace.yaml
+avocado-misc-tests/trace/dawr.py
+avocado-misc-tests/generic/ltp.py avocado-misc-tests/generic/ltp.py.data/ltp-tracing.yaml


### PR DESCRIPTION
Add cfg file for running trace test bucket. This trace bucket will run ftracetest, ptrace, dawr FEAT regression tests and ltp tracing tests.

Signed-off-by: Akanksha J N <akanksha@linux.ibm.com>

python avocado-setup.py --run-suite host_distro_trace --additional-args "\-d"
/root/avocado-fvt-wrapper/avocado-setup.py:38: DeprecationWarning: The SafeConfigParser class has been renamed to ConfigParser in Python 3.2. This alias will be removed in future versions. Use ConfigParser directly instead.
  CONFIGFILE = configparser.SafeConfigParser()
/root/avocado-fvt-wrapper/avocado-setup.py:40: DeprecationWarning: The SafeConfigParser class has been renamed to ConfigParser in Python 3.2. This alias will be removed in future versions. Use ConfigParser directly instead.
  NORUNTESTFILE = configparser.SafeConfigParser()
/root/avocado-fvt-wrapper/avocado-setup.py:42: DeprecationWarning: The SafeConfigParser class has been renamed to ConfigParser in Python 3.2. This alias will be removed in future versions. Use ConfigParser directly instead.
  INPUTFILE = configparser.SafeConfigParser()
22:55:15 INFO    : Check for environment
22:55:15 INFO    : Creating temporary mux dir
22:55:16 INFO    : 
22:55:16 INFO    : Running Host Tests Suite distro_trace_kselftest_ftracetest
22:55:16 INFO    : Running: /usr/local/bin/avocado run --max-parallel-tasks=1 /root/avocado-fvt-wrapper/tests/avocado-misc-tests/kernel/kselftest.py -m /root/avocado-fvt-wrapper/tests/avocado-misc-tests/kernel/kselftest.py.data/ftracetest.yaml --force-job-id e1d4219688f7e252e8966b44b27701330c958b00 \-d --job-results-dir /root/avocado-fvt-wrapper/results
JOB ID     : e1d4219688f7e252e8966b44b27701330c958b00
JOB LOG    : /root/avocado-fvt-wrapper/results/job-2023-01-19T22.55-e1d4219/job.log
 (1/2) /root/avocado-fvt-wrapper/tests/avocado-misc-tests/kernel/kselftest.py:kselftest.test;run-component-ftrace-run_type-distro-7b46: STARTED
 (1/2) /root/avocado-fvt-wrapper/tests/avocado-misc-tests/kernel/kselftest.py:kselftest.test;run-component-ftrace-run_type-distro-7b46: CANCEL: Test cancelled due to --dry-run (0.00 s)
 (2/2) /root/avocado-fvt-wrapper/tests/avocado-misc-tests/kernel/kselftest.py:kselftest.test;run-component-ftrace-run_type-upstream-2f43: STARTED
 (2/2) /root/avocado-fvt-wrapper/tests/avocado-misc-tests/kernel/kselftest.py:kselftest.test;run-component-ftrace-run_type-upstream-2f43: CANCEL: Test cancelled due to --dry-run (0.00 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 2
JOB HTML   : /root/avocado-fvt-wrapper/results/job-2023-01-19T22.55-e1d4219/results.html
JOB TIME   : 23.16 s
22:55:43 INFO    : 
22:55:43 INFO    : 
22:55:43 INFO    : Running Host Tests Suite distro_trace_kselftest_ptrace
22:55:43 INFO    : Running: /usr/local/bin/avocado run --max-parallel-tasks=1 /root/avocado-fvt-wrapper/tests/avocado-misc-tests/kernel/kselftest.py -m /root/avocado-fvt-wrapper/tests/avocado-misc-tests/kernel/kselftest.py.data/ptrace.yaml --force-job-id e7ee083086a6a5669041ae7f5ff2faf4c916f7cb \-d --job-results-dir /root/avocado-fvt-wrapper/results
JOB ID     : e7ee083086a6a5669041ae7f5ff2faf4c916f7cb
JOB LOG    : /root/avocado-fvt-wrapper/results/job-2023-01-19T22.55-e7ee083/job.log
 (1/2) /root/avocado-fvt-wrapper/tests/avocado-misc-tests/kernel/kselftest.py:kselftest.test;run-component-ptrace-run_type-distro-6a16: STARTED
 (1/2) /root/avocado-fvt-wrapper/tests/avocado-misc-tests/kernel/kselftest.py:kselftest.test;run-component-ptrace-run_type-distro-6a16: CANCEL: Test cancelled due to --dry-run (0.00 s)
 (2/2) /root/avocado-fvt-wrapper/tests/avocado-misc-tests/kernel/kselftest.py:kselftest.test;run-component-ptrace-run_type-upstream-e9bd: STARTED
 (2/2) /root/avocado-fvt-wrapper/tests/avocado-misc-tests/kernel/kselftest.py:kselftest.test;run-component-ptrace-run_type-upstream-e9bd: CANCEL: Test cancelled due to --dry-run (0.00 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 2
JOB HTML   : /root/avocado-fvt-wrapper/results/job-2023-01-19T22.55-e7ee083/results.html
JOB TIME   : 22.50 s
22:56:09 INFO    : 
22:56:09 INFO    : 
22:56:09 INFO    : Running Host Tests Suite distro_trace_dawr
22:56:09 INFO    : Running: /usr/local/bin/avocado run --max-parallel-tasks=1 /root/avocado-fvt-wrapper/tests/avocado-misc-tests/trace/dawr.py --force-job-id f2523dc941eec8ddd631290e17bfeaf66f16fb2a \-d --job-results-dir /root/avocado-fvt-wrapper/results
JOB ID     : f2523dc941eec8ddd631290e17bfeaf66f16fb2a
JOB LOG    : /root/avocado-fvt-wrapper/results/job-2023-01-19T22.56-f2523dc/job.log
 (1/3) /root/avocado-fvt-wrapper/tests/avocado-misc-tests/trace/dawr.py:Dawr.test_read_dawr_v1: STARTED
 (1/3) /root/avocado-fvt-wrapper/tests/avocado-misc-tests/trace/dawr.py:Dawr.test_read_dawr_v1: CANCEL: Test cancelled due to --dry-run (0.00 s)
 (2/3) /root/avocado-fvt-wrapper/tests/avocado-misc-tests/trace/dawr.py:Dawr.test_read_dawr_v2: STARTED
 (2/3) /root/avocado-fvt-wrapper/tests/avocado-misc-tests/trace/dawr.py:Dawr.test_read_dawr_v2: CANCEL: Test cancelled due to --dry-run (0.00 s)
 (3/3) /root/avocado-fvt-wrapper/tests/avocado-misc-tests/trace/dawr.py:Dawr.test_read_dawr_v3: STARTED
 (3/3) /root/avocado-fvt-wrapper/tests/avocado-misc-tests/trace/dawr.py:Dawr.test_read_dawr_v3: CANCEL: Test cancelled due to --dry-run (0.00 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 3
JOB HTML   : /root/avocado-fvt-wrapper/results/job-2023-01-19T22.56-f2523dc/results.html
JOB TIME   : 22.94 s
22:56:35 INFO    : 
22:56:35 INFO    : 
22:56:35 INFO    : Running Host Tests Suite distro_trace_ltp_ltp-tracing
22:56:35 INFO    : Running: /usr/local/bin/avocado run --max-parallel-tasks=1 /root/avocado-fvt-wrapper/tests/avocado-misc-tests/generic/ltp.py -m /root/avocado-fvt-wrapper/tests/avocado-misc-tests/generic/ltp.py.data/ltp-tracing.yaml --force-job-id 9563d8fd01a8ea3eaee811d036765fad7734898d \-d --job-results-dir /root/avocado-fvt-wrapper/results
JOB ID     : 9563d8fd01a8ea3eaee811d036765fad7734898d
JOB LOG    : /root/avocado-fvt-wrapper/results/job-2023-01-19T22.56-9563d8f/job.log
 (1/1) /root/avocado-fvt-wrapper/tests/avocado-misc-tests/generic/ltp.py:LTP.test;run-runltp-tracing-a507: STARTED
 (1/1) /root/avocado-fvt-wrapper/tests/avocado-misc-tests/generic/ltp.py:LTP.test;run-runltp-tracing-a507: CANCEL: Test cancelled due to --dry-run (0.00 s)
RESULTS    : PASS 0 | ERROR 0 | FAIL 0 | SKIP 0 | WARN 0 | INTERRUPT 0 | CANCEL 1
JOB HTML   : /root/avocado-fvt-wrapper/results/job-2023-01-19T22.56-9563d8f/results.html
JOB TIME   : 22.55 s
22:57:02 INFO    : 
22:57:02 INFO    : Summary of test results can be found below:
TestSuite                                   TestRun    Summary
 
host_distro_trace_kselftest_ftracetest      Not_Run    Unable to find job log file

 
host_distro_trace_kselftest_ptrace          Not_Run    Unable to find job log file

 
host_distro_trace_dawr                      Not_Run    Unable to find job log file

 
host_distro_trace_ltp_ltp-tracing           Not_Run    Unable to find job log file

22:57:02 INFO    : Removing temporary mux dir