### PR TITLE
RAS: remove libvirt_bench.dump_with_unixbench test

### DIFF
--- a/config/tests/guest/libvirt/ras.cfg
+++ b/config/tests/guest/libvirt/ras.cfg
@@ -63,7 +63,5 @@ variants:
             - negative:
                 only virsh.dump.negative_test
 
-    - guest_dump_with_unixbench:
-        only libvirt_bench.dump_with_unixbench
     - guest_remove:
         only remove_guest.without_disk


### PR DESCRIPTION
Signed-off-by: Kowshik Jois B S <kowsjois@linux.ibm.com>

The test fails with a dependency error for the module 'autotest' .
(2/3) type_specific.io-github-autotest-libvirt.libvirt_bench.dump_with_unixbench: ERROR: No module named 'autotest' (36.57 s)

autotest needs python2 to be available to get installed. Since python2 is sunset and autotest also not active, disabling this test for now.